### PR TITLE
Feature/v0.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ NyanPUI(にゃんぷい)は、GoLangで作られたサーバーサイドレン�
 * **JavaScript エンジン**: Goja (ECMAScript 5.1 準拠) – [https://github.com/dop251/goja](https://github.com/dop251/goja)
 * **双方向通信**: gorilla/websocket による WebSocket
 * **プッシュ通知**: 特定エンドポイントの処理結果を WebSocket で配信
+* **定期実行**: `type: "schedule"` による cron 形式の JavaScript ジョブ
+* **CORS**: `Access-Control-Allow-Origin: *` を付与
 
 ## ライセンス
 
@@ -97,17 +99,21 @@ MIT ライセンスです。詳細は [LICENSE.md](LICENSE.md) を参照して�
 }
 ```
 
+* **type**: 種別。省略時は通常 API、`public` は静的ファイル公開、`ws_client` は WebSocket クライアント、`schedule` は定期実行ジョブ
 * **script**: 実行する JavaScript ファイル（空文字列なら HTML のみ返却）
 * **html**: HTML ファイルパス
 * **path**: `type: "public"` で公開するフォルダパス
+* **trigger**: `type: "schedule"` で使う実行トリガー
 * **paramCheck**: API 実行前に実行する JavaScript ファイル
 * **outCheck**: API 出力前に実行する JavaScript ファイル
 * **description**: 説明文
 * **push**: WebSocket で配信するエンドポイント名
 
-省略可能なフィールド: `script`, `paramCheck`, `outCheck`, `push`。
+省略可能なフィールド: `type`, `script`, `html`, `path`, `connectURL`, `trigger`, `paramCheck`, `outCheck`, `description`, `push`。
 
 `paramCheck` は `paramcheck`、`outCheck` は `outcheck` の小文字表記でも読み込めます。README では `paramCheck` / `outCheck` を推奨表記とします。
+
+通常 API は `GET`, `POST`, `PUT`, `DELETE` などのメソッドを受け付けます。`Content-Type: application/json` の JSON body、フォーム値、URL クエリを `nyanAllParams` にまとめて渡します。`api` が未指定の場合は、エンドポイントパスまたは `html` が入ります。
 
 ### public フォルダ公開（`type: "public"`）
 
@@ -296,6 +302,18 @@ return {
 
 `connectURL` は `env:WS_URL` のように環境変数からも指定できます。
 
+受信したメッセージは `script` に渡され、次の値を `nyanAllParams` で参照できます。`script` の戻り値が空でない場合は、接続先 WebSocket にテキストメッセージとして返信します。切断時は 1 秒から最大 30 秒までの指数バックオフで再接続します。
+
+| キー | 内容 |
+| --- | --- |
+| `ws_client` | ws_client 名 |
+| `ws_message_type` | `text`, `binary`, `close`, `ping`, `pong` など |
+| `ws_message_text` | 受信内容の文字列 |
+| `ws_message_base64` | バイナリ受信時の Base64 文字列 |
+| `ws_message_json` | テキスト受信内容が JSON として読めた場合の値 |
+| `ws_connect_url` | 接続先 URL |
+| `ws_description` | `api.json` の説明文 |
+
 #### 動作確認（NyanPUI 自身に接続）
 
 リポジトリ同梱の `api.json` には、NyanPUI 自身の `/push/receive` に接続するサンプル（`ws_client/self_push_receive`）があります。
@@ -306,10 +324,52 @@ return {
 
 ポートを変更している場合は `api.json` の `connectURL` を合わせてください。
 
+### 定期実行ジョブ（`type: "schedule"`）
+
+`type: "schedule"` を指定すると、NyanPUI の起動時に定期実行ジョブとして登録されます。HTTP エンドポイント、`/nyan` の API 一覧、JSON-RPC には公開されません。
+
+```json
+{
+  "schedule_debug_every_minute": {
+    "type": "schedule",
+    "script": "./javascript/schedule_debug.js",
+    "trigger": {
+      "type": "cron",
+      "value": "* * * * *"
+    },
+    "description": "schedule の動作確認用。1分ごとにログへ実行時刻を出力します。"
+  }
+}
+```
+
+現在サポートしている `trigger.type` は `cron` です。`trigger.value` は `分 時 日 月 曜日` の 5 フィールドで指定します。
+
+例:
+
+```text
+* * * * *          # 毎分
+*/15 9-10 * * 1-5 # 平日 9:00-10:59 の15分ごと
+0 10 * * *         # 毎日 10:00
+```
+
+schedule の `script` では通常 API と同じ Goja 環境を使えます。加えて `nyanAllParams` に次の値が入ります。
+
+| キー | 内容 |
+| --- | --- |
+| `nyan_job_name` | ジョブ名 |
+| `nyan_schedule_trigger_type` | トリガー種別。現在は `cron` |
+| `nyan_schedule_trigger` | cron 式 |
+| `nyan_schedule_time` | 実行予定時刻 |
+| `nyan_schedule_description` | `api.json` の説明文 |
+
+同梱の `api.json` には動作確認用の `schedule_debug_every_minute` を追加しています。起動すると1分ごとに `javascript/schedule_debug.js` が実行され、ログへ実行時刻が出力されます。
+
 ## アプリケーションの実行
 
 * `config.json` と `api.json` を編集後、実行ファイルを起動。
 * デフォルトで [http://localhost:8009/](http://localhost:8009/) にアクセスするとサンプルが表示されます。 Windows MacOS Linuxで実行可能です。 各自でビルドいただくか、[リリース](https://github.com/NyanQL/NyanPUI/releases)からダウンロードしてください。
+* `/nyan` にアクセスすると、`type: "schedule"` 以外の API 一覧を JSON で取得できます。
+* `/css`, `/images`, `/js`, `/favicon.ico` は `html/` 配下の静的ファイルとして配信されます。
 
 ## ビルド
 
@@ -412,15 +472,16 @@ var response = nyanCallAPI("https://api.example.com/data", postData, "nyan", "pa
 ### 7. **nyanHostExec**
 ホスト側でコマンドを実行し、結果を取得します。
 ```javascript
-var result = nyanHostExec("ls -la");
-console.log("Command Result: " + result);
+var result = JSON.parse(nyanHostExec("ls -la"));
+console.log("Command Result: " + result.stdout);
 ```
-結果は次のようになります。上記例ですと、下記の stdoutにlsコマンドの結果が格納されます。
+戻り値は JSON 文字列です。上記例では `stdout` に ls コマンドの結果が格納されます。
 ```json
 {
+  "success": true,
+  "exit_code": 0,
   "stdout": "コマンドの標準出力",
-  "stderr": "コマンドの標準エラー出力",
-  "exit_code": 0
+  "stderr": "コマンドの標準エラー出力"
 }
 ```
 
@@ -435,7 +496,7 @@ console.log("File Content: " + fileContent);
 
 ### 9. **nyanReadFileB64**
 バイナリファイルをBase64文字列として取得します。
-ファイルのパスはカレントディレクトリからの相対パスでも指定できます。
+ファイルのパスはカレントディレクトリからの相対パス、または絶対パスで指定できます。存在しない場合は JavaScript 例外になります。
 ```javascript
 var b64 = nyanReadFileB64("./html/images/nyan.png");
 console.log(b64);
@@ -455,6 +516,7 @@ console.log(result);
 * 引数オブジェクトは呼び出し先 API の `nyanAllParams` に渡されます（`api` は呼び出し先名で上書き）。
 * 呼び出し先の戻り値が JSON 文字列の場合は自動でオブジェクト化されます。
 * `type: "ws_client"` のエンドポイントは `nyanCallMe` では呼び出せません。
+* `type: "schedule"` のエンドポイントは `nyanCallMe` では呼び出せません。
 * 現在処理中 API 名を解決できない場合（例: `ws_client` から `api` 未指定で呼ぶ場合）は例外になります。
 * 失敗時は JavaScript 側で例外になります。
 
@@ -482,10 +544,12 @@ JSON-RPC 2.0 API を実装しています。（Batch は未実装）。
 }
 ```
 
+`method` には `api.json` の API 名を指定します。JSON-RPC では `script` が必須です。`type: "schedule"` は呼び出せません。成功時の `result` は JavaScript の戻り値を文字列化した値です。
+
 ---
 
 ## JavaScriptのレスポンス形式（拡張）
-JavaScript が文字列を返した場合は従来どおり HTML として返します。
+JavaScript が文字列を返した場合は従来どおり `text/html; charset=utf-8` として返します。`null` や `undefined` の場合は空ボディになります。
 オブジェクトを返すと、HTTPレスポンスを制御できます。
 
 ```javascript
@@ -497,7 +561,7 @@ JavaScript が文字列を返した場合は従来どおり HTML として返し
 });
 ```
 
-バイナリを返す場合は `body.encoding = "base64"` を指定します。
+`body` に配列やオブジェクトを指定した場合は JSON として返します。バイナリを返す場合は `body.encoding = "base64"` を指定します。
 
 ```javascript
 const data = nyanReadFileB64("./html/images/nyan.png");
@@ -513,6 +577,7 @@ const data = nyanReadFileB64("./html/images/nyan.png");
 
 - `http://localhost:8009/sample/json`
 - `http://localhost:8009/sample/png`
+- `schedule_debug_every_minute`（HTTP では公開されない定期実行ジョブ）
 
 ---
 
@@ -527,4 +592,4 @@ const data = nyanReadFileB64("./html/images/nyan.png");
 
 
 ## 予約語
-`api` と `nyan` で始まる文字列を避けてください。
+エンドポイント名や変数名など、`nyan` で始まる名前は予約語になりますので使用しないでください。`nyan`, `nyan-rpc` は固定ルートで使われます。`api` は `nyanAllParams` で呼び出し先 API 名に使う予約パラメータです。

--- a/README.md
+++ b/README.md
@@ -100,10 +100,14 @@ MIT ライセンスです。詳細は [LICENSE.md](LICENSE.md) を参照して�
 * **script**: 実行する JavaScript ファイル（空文字列なら HTML のみ返却）
 * **html**: HTML ファイルパス
 * **path**: `type: "public"` で公開するフォルダパス
+* **paramCheck**: API 実行前に実行する JavaScript ファイル
+* **outCheck**: API 出力前に実行する JavaScript ファイル
 * **description**: 説明文
 * **push**: WebSocket で配信するエンドポイント名
 
-省略可能なフィールド: `script`, `push`。
+省略可能なフィールド: `script`, `paramCheck`, `outCheck`, `push`。
+
+`paramCheck` は `paramcheck`、`outCheck` は `outcheck` の小文字表記でも読み込めます。README では `paramCheck` / `outCheck` を推奨表記とします。
 
 ### public フォルダ公開（`type: "public"`）
 
@@ -120,6 +124,160 @@ MIT ライセンスです。詳細は [LICENSE.md](LICENSE.md) を参照して�
 ```
 
 この例では `./public/app.js` を `http://localhost:8009/public/app.js` で取得できます。リクエスト先が実在するファイルではない場合は 404 を返します。フォルダへのアクセスでは `index.html` を探さず、ディレクトリ一覧も表示しません。
+
+### 実行前チェック（`paramCheck`）
+
+`paramCheck` を指定すると、通常 API の `script` 実行前、または `type: "public"` のファイル配信前に JavaScript を実行できます。
+
+```json
+{
+  "private-files": {
+    "type": "public",
+    "path": "./public/private",
+    "paramCheck": "./javascript/check_login.js",
+    "description": "認証付きファイル"
+  }
+}
+```
+
+通常 API にも同じように指定できます。
+
+```json
+{
+  "private-api": {
+    "script": "./javascript/private_api.js",
+    "html": "./html/private.html",
+    "paramCheck": "./javascript/check_login.js",
+    "description": "認証付きAPI"
+  }
+}
+```
+
+`paramCheck` は次の JSON 形式を返します。
+
+```js
+return {
+  success: true,
+  status: 200,
+  result: {}
+};
+```
+
+`success: true` かつ `status: 200` の場合だけ次の処理へ進みます。それ以外は `paramCheck` の結果を JSON として返します。HTTP ステータスも `status` の値になります。
+
+```js
+return {
+  success: false,
+  status: 401,
+  result: {
+    message: "login required"
+  }
+};
+```
+
+`nyan_mode=checkOnly` を指定した場合は `paramCheck` だけを実行し、成功時も本処理へ進まずチェック結果を返します。`paramCheck` 未設定の場合は次を返します。
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "result": null
+}
+```
+
+`type: "public"` の `paramCheck` では、リクエストされた公開ファイルの情報を参照できます。
+
+```js
+var endpoint = nyanAllParams.nyan_public_endpoint; // 例: "public"
+var path = nyanAllParams.nyan_public_path;         // 例: "docs/a.txt"
+```
+
+絶対パスは渡しません。認証・認可判定には公開フォルダ内の相対パスを使ってください。
+
+### 出力前チェック（`outCheck`）
+
+`outCheck` を指定すると、通常 API の本体実行後、または `type: "public"` のファイル送信前に JavaScript を実行できます。`outCheck` が成功した場合は本体の実行結果をそのまま出力し、失敗した場合は `outCheck` の結果を JSON として出力します。
+
+```json
+{
+  "checked-api": {
+    "script": "./javascript/main.js",
+    "outCheck": "./javascript/out_check.js",
+    "description": "出力前チェック付きAPI"
+  }
+}
+```
+
+`type: "public"` にも指定できます。この場合、ファイル送信前にファイル内容を `outCheck` へ渡して検査します。
+
+```json
+{
+  "public": {
+    "type": "public",
+    "path": "./public",
+    "paramCheck": "./javascript/check_login.js",
+    "outCheck": "./javascript/out_check.js",
+    "description": "チェック付き public フォルダ"
+  }
+}
+```
+
+`outCheck` は `paramCheck` と同じ JSON 形式を返します。
+
+```js
+return {
+  success: true,
+  status: 200,
+  result: {}
+};
+```
+
+`success: true` かつ `status: 200` の場合だけ本体の実行結果をそのまま出力します。それ以外は `outCheck` の結果を JSON として返します。HTTP ステータスも `status` の値になります。
+
+本体の実行結果は `nyanAllParams.nyan_output` で参照できます。
+
+```js
+if (nyanAllParams.nyan_output.body.indexOf("expected") >= 0) {
+  return {
+    success: true,
+    status: 200,
+    result: {}
+  };
+}
+
+return {
+  success: false,
+  status: 409,
+  result: {
+    message: "output mismatch"
+  }
+};
+```
+
+`nyan_output` には `status`, `contentType`, `headers`, `body`, `bodyBase64`, `bodyLength` が入ります。互換用に `nyan_output_status`, `nyan_output_content_type`, `nyan_output_body`, `nyan_output_body_base64` も利用できます。
+
+`type: "public"` の `outCheck` でも、リクエストされた公開ファイル名を参照できます。
+
+```js
+var path = nyanAllParams.nyan_public_path;
+
+if (path === "test.txt" && nyanAllParams.nyan_output.body === "expected") {
+  return {
+    success: true,
+    status: 200,
+    result: {}
+  };
+}
+
+return {
+  success: false,
+  status: 409,
+  result: {
+    message: "file output mismatch",
+    path: path
+  }
+};
+```
 
 ### WebSocket レシーバー（`type: "ws_client"`）
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,27 @@ MIT ライセンスです。詳細は [LICENSE.md](LICENSE.md) を参照して�
 
 * **script**: 実行する JavaScript ファイル（空文字列なら HTML のみ返却）
 * **html**: HTML ファイルパス
+* **path**: `type: "public"` で公開するフォルダパス
 * **description**: 説明文
 * **push**: WebSocket で配信するエンドポイント名
 
 省略可能なフィールド: `script`, `push`。
+
+### public フォルダ公開（`type: "public"`）
+
+`type: "public"` を指定すると、`path` のフォルダ配下にあるファイルをそのまま配信します。`path` は実行ファイルのあるディレクトリからの相対パス、または絶対パスで指定できます。
+
+```json
+{
+  "public": {
+    "type": "public",
+    "path": "./public",
+    "description": "public フォルダ"
+  }
+}
+```
+
+この例では `./public/app.js` を `http://localhost:8009/public/app.js` で取得できます。リクエスト先が実在するファイルではない場合は 404 を返します。フォルダへのアクセスでは `index.html` を探さず、ディレクトリ一覧も表示しません。
 
 ### WebSocket レシーバー（`type: "ws_client"`）
 

--- a/api.json
+++ b/api.json
@@ -2,7 +2,8 @@
   "html": {
     "script": "./javascript/html.js",
     "html": "./html/index.html",
-    "description": "トップページです"
+    "description": "トップページです",
+    "outcheck": "./javascript/sample_outcheck.js"
   },
   "wf": {
     "html": "./html/wf_html.html",

--- a/api.json
+++ b/api.json
@@ -49,5 +49,14 @@
     "script": "./javascript/sample_png.js",
     "html": "",
     "description": "nyan.pngをバイナリで返すサンプルAPI"
+  },
+  "schedule_debug_every_minute": {
+    "type": "schedule",
+    "script": "./javascript/schedule_debug.js",
+    "trigger": {
+      "type": "cron",
+      "value": "* * * * *"
+    },
+    "description": "schedule の動作確認用。1分ごとにログへ実行時刻を出力します。"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module Nyan8
 
-go 1.22
+go 1.26
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/javascript/sample_outcheck.js
+++ b/javascript/sample_outcheck.js
@@ -1,0 +1,6 @@
+console.log(nyanAllParams.nyan_public_path) //リクエストされたファイルのパス フォルダからの相対パス
+JSON.stringify({
+  success: true,
+  status: 200,
+  result: { outcheck: '出力check' }
+})

--- a/javascript/sample_paramcheck.js
+++ b/javascript/sample_paramcheck.js
@@ -1,0 +1,5 @@
+JSON.stringify({
+  success: true,
+  status: 200,
+  result: {}
+})

--- a/javascript/schedule_debug.js
+++ b/javascript/schedule_debug.js
@@ -1,0 +1,20 @@
+const now = new Date()
+
+console.log(
+  '[schedule_debug]',
+  'executed_at=' + now.toISOString(),
+  'job=' + nyanAllParams.nyan_job_name,
+  'scheduled_at=' + nyanAllParams.nyan_schedule_time,
+  'trigger=' + nyanAllParams.nyan_schedule_trigger
+)
+
+JSON.stringify({
+  success: true,
+  status: 200,
+  data: {
+    message: 'schedule_debug executed at ' + now.toISOString(),
+    job: nyanAllParams.nyan_job_name,
+    scheduled_at: nyanAllParams.nyan_schedule_time,
+    trigger: nyanAllParams.nyan_schedule_trigger
+  }
+})

--- a/main.go
+++ b/main.go
@@ -68,9 +68,32 @@ type EndpointConfig struct {
 	Script      string `json:"script"`
 	HTML        string `json:"html"`
 	Path        string `json:"path,omitempty"`
+	ParamCheck  string `json:"paramCheck,omitempty"`
+	OutCheck    string `json:"outCheck,omitempty"`
 	ConnectURL  string `json:"connectURL,omitempty"`
 	Description string `json:"description"`
 	Push        string `json:"push,omitempty"`
+}
+
+func (e *EndpointConfig) UnmarshalJSON(data []byte) error {
+	type endpointConfigAlias EndpointConfig
+	var raw struct {
+		endpointConfigAlias
+		ParamCheckLower string `json:"paramcheck"`
+		OutCheckLower   string `json:"outcheck"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*e = EndpointConfig(raw.endpointConfigAlias)
+	if strings.TrimSpace(e.ParamCheck) == "" {
+		e.ParamCheck = raw.ParamCheckLower
+	}
+	if strings.TrimSpace(e.OutCheck) == "" {
+		e.OutCheck = raw.OutCheckLower
+	}
+	return nil
 }
 
 type APIConfig map[string]EndpointConfig
@@ -112,6 +135,19 @@ type JSONRPCError struct {
 	Code    int         `json:"code"`
 	Message string      `json:"message"`
 	Data    interface{} `json:"data,omitempty"`
+}
+
+type ParamCheckResponse struct {
+	Success bool        `json:"success"`
+	Status  int         `json:"status"`
+	Result  interface{} `json:"result"`
+}
+
+type APIResponse struct {
+	Status      int
+	ContentType string
+	Headers     map[string]string
+	Body        []byte
 }
 
 // このシステムの設定
@@ -313,37 +349,10 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 	ginContext = c
 	defer func() { ginContext = nil }()
 
-	// リクエストのコンテンツタイプを取得
-	contentType := c.ContentType()
-
-	// リクエストパラメータの収集
-	allParams := make(map[string]interface{})
-	if contentType == "application/json" {
-		var requestData map[string]interface{}
-		if err := c.BindJSON(&requestData); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON data"})
-			return
-		}
-		for k, v := range requestData {
-			allParams[k] = v
-		}
-	}
-
-	// URLクエリパラメータとPOSTフォームパラメータを追加
-	c.Request.ParseForm()
-	for k, v := range c.Request.PostForm {
-		allParams[k] = v[0]
-	}
-	for k, v := range c.Request.URL.Query() {
-		allParams[k] = v[0]
-	}
-
-	if allParams["api"] == nil {
-		if c.Request.URL.Path != "/" {
-			allParams["api"] = c.Request.URL.Path
-		} else {
-			allParams["api"] = "html"
-		}
+	allParams, err := collectRequestParams(c, "")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON data"})
+		return
 	}
 
 	// スクリプトとHTMLファイルのパスを取得
@@ -353,6 +362,12 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 		htmlPath = resolvePath(exeDir, config.HTML)
 	}
 
+	if allowed, handled := runParamCheck(c, config, exeDir, htmlPath, allParams); handled {
+		return
+	} else if !allowed {
+		return
+	}
+
 	// scriptが空の場合、HTMLファイルの内容をそのまま返す
 	if config.Script == "" {
 		htmlContent, err := os.ReadFile(htmlPath)
@@ -360,7 +375,16 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load HTML file"})
 			return
 		}
-		c.Data(http.StatusOK, "text/html; charset=utf-8", htmlContent)
+		response := APIResponse{
+			Status:      http.StatusOK,
+			ContentType: "text/html; charset=utf-8",
+			Headers:     map[string]string{},
+			Body:        htmlContent,
+		}
+		if handled := runOutCheck(c, config, exeDir, htmlPath, allParams, response); handled {
+			return
+		}
+		writeAPIResponse(c, response)
 		return
 	}
 
@@ -371,15 +395,20 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 		return
 	}
 
-	if handled, err := writeJSResponse(c, resultValue); err != nil {
+	response, handledJSResponse, err := responseFromJSValue(resultValue)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	} else if handled {
 		return
 	}
 
-	// HTML出力として結果を返す
-	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(resultValue.String()))
+	if handled := runOutCheck(c, config, exeDir, htmlPath, allParams, response); handled {
+		return
+	}
+
+	writeAPIResponse(c, response)
+	if handledJSResponse {
+		return
+	}
 
 	// push 設定がある場合、対象のWebSocket接続に対してプッシュ
 	// API リクエスト完了後の push 処理
@@ -618,57 +647,253 @@ func runJavaScriptValue(scriptPath string, htmlPath string, allParams map[string
 	return value, nil
 }
 
-func writeJSResponse(c *gin.Context, value goja.Value) (bool, error) {
+func collectRequestParams(c *gin.Context, defaultAPI string) (map[string]interface{}, error) {
+	allParams := make(map[string]interface{})
+	if c.ContentType() == "application/json" {
+		var requestData map[string]interface{}
+		if err := c.ShouldBindJSON(&requestData); err != nil {
+			return nil, err
+		}
+		for key, value := range requestData {
+			allParams[key] = value
+		}
+	}
+
+	c.Request.ParseForm()
+	for key, value := range c.Request.PostForm {
+		allParams[key] = value[0]
+	}
+	for key, value := range c.Request.URL.Query() {
+		allParams[key] = value[0]
+	}
+
+	if allParams["api"] == nil {
+		if strings.TrimSpace(defaultAPI) != "" {
+			allParams["api"] = defaultAPI
+		} else if c.Request.URL.Path != "/" {
+			allParams["api"] = c.Request.URL.Path
+		} else {
+			allParams["api"] = "html"
+		}
+	}
+
+	return allParams, nil
+}
+
+func runParamCheck(c *gin.Context, config EndpointConfig, exeDir string, htmlPath string, allParams map[string]interface{}) (bool, bool) {
+	checkOnly := isCheckOnlyMode(allParams)
+	paramCheckPath := strings.TrimSpace(config.ParamCheck)
+	if paramCheckPath == "" {
+		if checkOnly {
+			writeParamCheckResponse(c, ParamCheckResponse{
+				Success: true,
+				Status:  http.StatusOK,
+				Result:  nil,
+			})
+			return false, true
+		}
+		return true, false
+	}
+
+	c.Writer.Header().Set("Cache-Control", "no-store")
+	c.Writer.Header().Set("Pragma", "no-cache")
+
+	resultValue, err := runJavaScriptValue(resolvePath(exeDir, paramCheckPath), htmlPath, allParams)
+	if err != nil {
+		writeParamCheckResponse(c, newParamCheckError(http.StatusInternalServerError, err.Error()))
+		return false, true
+	}
+
+	checkResponse, err := parseCheckResponse(resultValue, "paramCheck")
+	if err != nil {
+		writeParamCheckResponse(c, newParamCheckError(http.StatusInternalServerError, err.Error()))
+		return false, true
+	}
+
+	allowed := checkResponse.Success && checkResponse.Status == http.StatusOK
+	if checkOnly || !allowed {
+		writeParamCheckResponse(c, checkResponse)
+		return allowed, true
+	}
+
+	return true, false
+}
+
+func isCheckOnlyMode(allParams map[string]interface{}) bool {
+	if allParams == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(fmt.Sprint(allParams["nyan_mode"])), "checkOnly")
+}
+
+func runOutCheck(c *gin.Context, config EndpointConfig, exeDir string, htmlPath string, allParams map[string]interface{}, response APIResponse) bool {
+	outCheckPath := strings.TrimSpace(config.OutCheck)
+	if outCheckPath == "" {
+		return false
+	}
+
+	checkParams := cloneParams(allParams)
+	checkParams["nyan_output"] = map[string]interface{}{
+		"status":          response.Status,
+		"contentType":     response.ContentType,
+		"headers":         response.Headers,
+		"body":            string(response.Body),
+		"bodyBase64":      base64.StdEncoding.EncodeToString(response.Body),
+		"bodyLength":      len(response.Body),
+		"bodyLengthBytes": len(response.Body),
+	}
+	checkParams["nyan_output_status"] = response.Status
+	checkParams["nyan_output_content_type"] = response.ContentType
+	checkParams["nyan_output_body"] = string(response.Body)
+	checkParams["nyan_output_body_base64"] = base64.StdEncoding.EncodeToString(response.Body)
+
+	resultValue, err := runJavaScriptValue(resolvePath(exeDir, outCheckPath), htmlPath, checkParams)
+	if err != nil {
+		writeParamCheckResponse(c, newParamCheckError(http.StatusInternalServerError, err.Error()))
+		return true
+	}
+
+	checkResponse, err := parseCheckResponse(resultValue, "outCheck")
+	if err != nil {
+		writeParamCheckResponse(c, newParamCheckError(http.StatusInternalServerError, err.Error()))
+		return true
+	}
+
+	if checkResponse.Success && checkResponse.Status == http.StatusOK {
+		return false
+	}
+
+	writeParamCheckResponse(c, checkResponse)
+	return true
+}
+
+func cloneParams(params map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(params))
+	for key, value := range params {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func parseCheckResponse(value goja.Value, checkName string) (ParamCheckResponse, error) {
 	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
-		return false, nil
+		return ParamCheckResponse{}, fmt.Errorf("%s must return an object", checkName)
 	}
 
 	exported := value.Export()
 	respMap, ok := exported.(map[string]interface{})
 	if !ok {
-		return false, nil
+		if text, ok := exported.(string); ok {
+			if err := json.Unmarshal([]byte(text), &respMap); err != nil {
+				return ParamCheckResponse{}, fmt.Errorf("%s string response must be JSON: %w", checkName, err)
+			}
+		} else {
+			return ParamCheckResponse{}, fmt.Errorf("%s must return an object", checkName)
+		}
 	}
 
-	status := http.StatusOK
+	success, ok := respMap["success"].(bool)
+	if !ok {
+		return ParamCheckResponse{}, fmt.Errorf("%s response success must be boolean", checkName)
+	}
+
+	status, ok := parseStatusCode(respMap["status"])
+	if !ok {
+		return ParamCheckResponse{}, fmt.Errorf("%s response status must be a number", checkName)
+	}
+	if status < 100 || status > 599 {
+		return ParamCheckResponse{}, fmt.Errorf("%s response status is out of range: %d", checkName, status)
+	}
+
+	return ParamCheckResponse{
+		Success: success,
+		Status:  status,
+		Result:  respMap["result"],
+	}, nil
+}
+
+func newParamCheckError(status int, message string) ParamCheckResponse {
+	return ParamCheckResponse{
+		Success: false,
+		Status:  status,
+		Result: map[string]interface{}{
+			"message": message,
+		},
+	}
+}
+
+func writeParamCheckResponse(c *gin.Context, resp ParamCheckResponse) {
+	status := resp.Status
+	if status < 100 || status > 599 {
+		status = http.StatusInternalServerError
+		resp.Status = status
+	}
+	c.JSON(status, resp)
+}
+
+func responseFromJSValue(value goja.Value) (APIResponse, bool, error) {
+	response := APIResponse{
+		Status:      http.StatusOK,
+		ContentType: "text/html; charset=utf-8",
+		Headers:     map[string]string{},
+		Body:        []byte{},
+	}
+
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return response, false, nil
+	}
+
+	exported := value.Export()
+	respMap, ok := exported.(map[string]interface{})
+	if !ok {
+		response.Body = []byte(value.String())
+		return response, false, nil
+	}
+
 	if rawStatus, ok := respMap["status"]; ok {
 		if parsed, ok := parseStatusCode(rawStatus); ok {
-			status = parsed
+			response.Status = parsed
 		}
 	}
 
-	contentType := ""
 	if rawContentType, ok := respMap["contentType"]; ok {
 		if s, ok := rawContentType.(string); ok {
-			contentType = s
+			response.ContentType = s
 		} else {
-			contentType = fmt.Sprint(rawContentType)
+			response.ContentType = fmt.Sprint(rawContentType)
 		}
 	}
 
-	headers := map[string]string{}
 	if rawHeaders, ok := respMap["headers"]; ok {
 		if headerMap, ok := rawHeaders.(map[string]interface{}); ok {
 			for key, value := range headerMap {
-				headers[key] = fmt.Sprint(value)
+				response.Headers[key] = fmt.Sprint(value)
 			}
 		}
 	}
 
 	bodyBytes, err := jsBodyToBytes(respMap["body"])
 	if err != nil {
-		return true, err
+		return response, true, err
 	}
+	response.Body = bodyBytes
+	return response, true, nil
+}
 
-	for key, value := range headers {
+func writeAPIResponse(c *gin.Context, response APIResponse) {
+	for key, value := range response.Headers {
 		c.Writer.Header().Set(key, value)
 	}
 
-	if strings.TrimSpace(contentType) == "" {
-		contentType = "text/html; charset=utf-8"
+	if strings.TrimSpace(response.ContentType) == "" {
+		response.ContentType = "text/html; charset=utf-8"
 	}
 
-	c.Data(status, contentType, bodyBytes)
-	return true, nil
+	if response.Status < 100 || response.Status > 599 {
+		response.Status = http.StatusInternalServerError
+	}
+
+	c.Data(response.Status, response.ContentType, response.Body)
 }
 
 func parseStatusCode(raw interface{}) (int, bool) {
@@ -749,6 +974,23 @@ func registerPublicEndpoint(r *gin.Engine, endpoint string, config EndpointConfi
 		}
 
 		requestedPath := strings.TrimPrefix(c.Param("filepath"), "/")
+		allParams, err := collectRequestParams(c, endpoint)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON data"})
+			return
+		}
+		allParams["nyan_public_endpoint"] = endpoint
+		allParams["nyan_public_path"] = requestedPath
+
+		ginContext = c
+		defer func() { ginContext = nil }()
+
+		if allowed, handled := runParamCheck(c, config, exeDir, "", allParams); handled {
+			return
+		} else if !allowed {
+			return
+		}
+
 		if requestedPath == "" || !filepath.IsLocal(requestedPath) {
 			c.Status(http.StatusNotFound)
 			return
@@ -767,6 +1009,23 @@ func registerPublicEndpoint(r *gin.Engine, endpoint string, config EndpointConfi
 		if fileInfo.IsDir() {
 			c.Status(http.StatusNotFound)
 			return
+		}
+
+		if strings.TrimSpace(config.OutCheck) != "" {
+			fileContent, err := os.ReadFile(filePath)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read public file"})
+				return
+			}
+			response := APIResponse{
+				Status:      http.StatusOK,
+				ContentType: http.DetectContentType(fileContent),
+				Headers:     map[string]string{},
+				Body:        fileContent,
+			}
+			if handled := runOutCheck(c, config, exeDir, "", allParams, response); handled {
+				return
+			}
 		}
 
 		c.File(filePath)
@@ -1405,6 +1664,9 @@ func nyanReadFileB64(vm *goja.Runtime) func(call goja.FunctionCall) goja.Value {
 
 func handleJSONRPC(c *gin.Context) {
 	log.Print("handleJSONRPC called")
+	ginContext = c
+	defer func() { ginContext = nil }()
+
 	// 1) リクエストボディを読み込み、JSONRPCRequest にパース
 	var rpcReq JSONRPCRequest
 	if err := c.ShouldBindJSON(&rpcReq); err != nil {
@@ -1463,6 +1725,12 @@ func handleJSONRPC(c *gin.Context) {
 	htmlPath := ""
 	if config.HTML != "" {
 		htmlPath = resolvePath(exeDir, config.HTML)
+	}
+
+	if allowed, handled := runParamCheck(c, config, exeDir, htmlPath, allParams); handled {
+		return
+	} else if !allowed {
+		return
 	}
 
 	// 7) メインのスクリプト実行（runJavaScript は既存関数）

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ type EndpointConfig struct {
 	Type        string `json:"type,omitempty"`
 	Script      string `json:"script"`
 	HTML        string `json:"html"`
+	Path        string `json:"path,omitempty"`
 	ConnectURL  string `json:"connectURL,omitempty"`
 	Description string `json:"description"`
 	Push        string `json:"push,omitempty"`
@@ -205,7 +206,11 @@ func main() {
 	// 各APIエンドポイントを設定
 	for endpoint := range apiConfig {
 		config := apiConfig[endpoint] // ループ変数をローカル変数にコピー
-		if strings.TrimSpace(config.Type) == apiTypeWSClient {
+		switch strings.TrimSpace(config.Type) {
+		case apiTypeWSClient:
+			continue
+		case apiTypePublic:
+			registerPublicEndpoint(r, endpoint, config, exeDir)
 			continue
 		}
 		r.Any("/"+endpoint, func(c *gin.Context) {
@@ -719,7 +724,59 @@ func jsBodyToBytes(body interface{}) ([]byte, error) {
 	}
 }
 
-const apiTypeWSClient = "ws_client"
+const (
+	apiTypeWSClient = "ws_client"
+	apiTypePublic   = "public"
+)
+
+func registerPublicEndpoint(r *gin.Engine, endpoint string, config EndpointConfig, exeDir string) {
+	routePath := "/" + strings.Trim(strings.TrimSpace(endpoint), "/")
+	if routePath == "/" {
+		log.Printf("public endpoint %q is invalid: endpoint name must not be empty", endpoint)
+		return
+	}
+
+	publicPath := strings.TrimSpace(config.Path)
+	if publicPath == "" {
+		log.Printf("public endpoint %s: path is missing", endpoint)
+	}
+
+	basePath := resolvePath(exeDir, publicPath)
+	handler := func(c *gin.Context) {
+		if publicPath == "" {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "public path is missing"})
+			return
+		}
+
+		requestedPath := strings.TrimPrefix(c.Param("filepath"), "/")
+		if requestedPath == "" || !filepath.IsLocal(requestedPath) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		filePath := filepath.Join(basePath, requestedPath)
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read public file"})
+			return
+		}
+		if fileInfo.IsDir() {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		c.File(filePath)
+	}
+
+	r.GET(routePath, handler)
+	r.HEAD(routePath, handler)
+	r.GET(routePath+"/*filepath", handler)
+	r.HEAD(routePath+"/*filepath", handler)
+}
 
 type wsClientConfig struct {
 	name        string

--- a/main.go
+++ b/main.go
@@ -64,15 +64,21 @@ type ErrorData struct {
 
 // EndpointConfig はエンドポイントの設定を表します。
 type EndpointConfig struct {
-	Type        string `json:"type,omitempty"`
-	Script      string `json:"script"`
-	HTML        string `json:"html"`
-	Path        string `json:"path,omitempty"`
-	ParamCheck  string `json:"paramCheck,omitempty"`
-	OutCheck    string `json:"outCheck,omitempty"`
-	ConnectURL  string `json:"connectURL,omitempty"`
-	Description string `json:"description"`
-	Push        string `json:"push,omitempty"`
+	Type        string        `json:"type,omitempty"`
+	Script      string        `json:"script"`
+	HTML        string        `json:"html"`
+	Path        string        `json:"path,omitempty"`
+	ParamCheck  string        `json:"paramCheck,omitempty"`
+	OutCheck    string        `json:"outCheck,omitempty"`
+	ConnectURL  string        `json:"connectURL,omitempty"`
+	Trigger     TriggerConfig `json:"trigger,omitempty"`
+	Description string        `json:"description"`
+	Push        string        `json:"push,omitempty"`
+}
+
+type TriggerConfig struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 func (e *EndpointConfig) UnmarshalJSON(data []byte) error {
@@ -226,6 +232,9 @@ func main() {
 	if err := startWebSocketClients(exeDir); err != nil {
 		log.Printf("Failed to start WebSocket clients: %v", err)
 	}
+	if err := startScheduleJobs(exeDir); err != nil {
+		log.Printf("Failed to start schedule jobs: %v", err)
+	}
 
 	gin.DisableConsoleColor()
 	r := gin.Default()
@@ -245,6 +254,8 @@ func main() {
 		switch strings.TrimSpace(config.Type) {
 		case apiTypeWSClient:
 			continue
+		case apiTypeSchedule:
+			continue
 		case apiTypePublic:
 			registerPublicEndpoint(r, endpoint, config, exeDir)
 			continue
@@ -259,6 +270,10 @@ func main() {
 		apiName := c.Query("api")
 		if apiName != "" {
 			if config, ok := apiConfig[apiName]; ok {
+				if strings.TrimSpace(config.Type) == apiTypeSchedule {
+					c.JSON(http.StatusNotFound, gin.H{"error": "API not found"})
+					return
+				}
 				handleAPIRequestOrWebSocket(c, config)
 				return
 			} else {
@@ -552,6 +567,9 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (interf
 	}
 	if strings.TrimSpace(apiCfg.Type) == apiTypeWSClient {
 		return nil, fmt.Errorf("API %s is ws_client and cannot be called by nyanCallMe", apiName)
+	}
+	if strings.TrimSpace(apiCfg.Type) == apiTypeSchedule {
+		return nil, fmt.Errorf("API %s is schedule and cannot be called by nyanCallMe", apiName)
 	}
 	if strings.TrimSpace(apiCfg.Script) == "" {
 		return nil, fmt.Errorf("script not found for API %s", apiName)
@@ -952,6 +970,7 @@ func jsBodyToBytes(body interface{}) ([]byte, error) {
 const (
 	apiTypeWSClient = "ws_client"
 	apiTypePublic   = "public"
+	apiTypeSchedule = "schedule"
 )
 
 func registerPublicEndpoint(r *gin.Engine, endpoint string, config EndpointConfig, exeDir string) {
@@ -1042,6 +1061,252 @@ type wsClientConfig struct {
 	scriptPath  string
 	connectURL  string
 	description string
+}
+
+type scheduleJobConfig struct {
+	name        string
+	scriptPath  string
+	trigger     TriggerConfig
+	description string
+	schedule    cronSchedule
+}
+
+type cronSchedule struct {
+	minutes     cronField
+	hours       cronField
+	days        cronField
+	months      cronField
+	weekdays    cronField
+	dayStar     bool
+	weekdayStar bool
+}
+
+type cronField map[int]bool
+
+func parseCronSchedule(expr string) (cronSchedule, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return cronSchedule{}, fmt.Errorf("cron expression must have 5 fields")
+	}
+
+	minutes, _, err := parseCronField(fields[0], 0, 59, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("minute field: %w", err)
+	}
+	hours, _, err := parseCronField(fields[1], 0, 23, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("hour field: %w", err)
+	}
+	days, dayStar, err := parseCronField(fields[2], 1, 31, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("day field: %w", err)
+	}
+	months, _, err := parseCronField(fields[3], 1, 12, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("month field: %w", err)
+	}
+	weekdays, weekdayStar, err := parseCronField(fields[4], 0, 7, true)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("weekday field: %w", err)
+	}
+
+	return cronSchedule{
+		minutes:     minutes,
+		hours:       hours,
+		days:        days,
+		months:      months,
+		weekdays:    weekdays,
+		dayStar:     dayStar,
+		weekdayStar: weekdayStar,
+	}, nil
+}
+
+func parseCronField(field string, minValue, maxValue int, normalizeSunday bool) (cronField, bool, error) {
+	values := make(cronField)
+	isStar := field == "*"
+	for _, part := range strings.Split(field, ",") {
+		if part == "" {
+			return nil, false, fmt.Errorf("empty list item")
+		}
+
+		step := 1
+		base := part
+		if strings.Contains(part, "/") {
+			stepParts := strings.Split(part, "/")
+			if len(stepParts) != 2 || stepParts[0] == "" || stepParts[1] == "" {
+				return nil, false, fmt.Errorf("invalid step %q", part)
+			}
+			base = stepParts[0]
+			parsedStep, err := strconv.Atoi(stepParts[1])
+			if err != nil || parsedStep <= 0 {
+				return nil, false, fmt.Errorf("invalid step %q", part)
+			}
+			step = parsedStep
+		}
+
+		start, end, err := cronRange(base, minValue, maxValue)
+		if err != nil {
+			return nil, false, err
+		}
+		for value := start; value <= end; value += step {
+			normalized := value
+			if normalizeSunday && normalized == 7 {
+				normalized = 0
+			}
+			values[normalized] = true
+		}
+	}
+
+	return values, isStar, nil
+}
+
+func cronRange(base string, minValue, maxValue int) (int, int, error) {
+	if base == "*" {
+		return minValue, maxValue, nil
+	}
+	if strings.Contains(base, "-") {
+		rangeParts := strings.Split(base, "-")
+		if len(rangeParts) != 2 || rangeParts[0] == "" || rangeParts[1] == "" {
+			return 0, 0, fmt.Errorf("invalid range %q", base)
+		}
+		start, err := strconv.Atoi(rangeParts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid range start %q", base)
+		}
+		end, err := strconv.Atoi(rangeParts[1])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid range end %q", base)
+		}
+		if start > end {
+			return 0, 0, fmt.Errorf("range start is greater than end %q", base)
+		}
+		if start < minValue || end > maxValue {
+			return 0, 0, fmt.Errorf("range %q is out of bounds %d-%d", base, minValue, maxValue)
+		}
+		return start, end, nil
+	}
+
+	value, err := strconv.Atoi(base)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid value %q", base)
+	}
+	if value < minValue || value > maxValue {
+		return 0, 0, fmt.Errorf("value %q is out of bounds %d-%d", base, minValue, maxValue)
+	}
+	return value, value, nil
+}
+
+func (s cronSchedule) next(after time.Time) time.Time {
+	next := after.Truncate(time.Minute).Add(time.Minute)
+	limit := next.AddDate(5, 0, 0)
+	for next.Before(limit) {
+		if s.matches(next) {
+			return next
+		}
+		next = next.Add(time.Minute)
+	}
+	return time.Time{}
+}
+
+func (s cronSchedule) matches(t time.Time) bool {
+	weekday := int(t.Weekday())
+	dayMatches := s.days[t.Day()]
+	weekdayMatches := s.weekdays[weekday]
+	switch {
+	case !s.dayStar && !s.weekdayStar:
+		if !dayMatches && !weekdayMatches {
+			return false
+		}
+	case !dayMatches || !weekdayMatches:
+		return false
+	}
+
+	return s.minutes[t.Minute()] &&
+		s.hours[t.Hour()] &&
+		s.months[int(t.Month())]
+}
+
+func startScheduleJobs(execDir string) error {
+	var firstErr error
+	for name, cfg := range apiConfig {
+		if strings.TrimSpace(cfg.Type) != apiTypeSchedule {
+			continue
+		}
+
+		scriptPath := strings.TrimSpace(cfg.Script)
+		trigger := cfg.Trigger
+		trigger.Type = strings.TrimSpace(trigger.Type)
+		trigger.Value = strings.TrimSpace(trigger.Value)
+
+		if scriptPath == "" {
+			err := fmt.Errorf("schedule %s: script is missing", name)
+			log.Print(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if trigger.Type != "cron" {
+			err := fmt.Errorf("schedule %s: unsupported trigger type %q", name, trigger.Type)
+			log.Print(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		schedule, err := parseCronSchedule(trigger.Value)
+		if err != nil {
+			err = fmt.Errorf("schedule %s: invalid cron trigger %q: %w", name, trigger.Value, err)
+			log.Print(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		jobCfg := scheduleJobConfig{
+			name:        name,
+			scriptPath:  resolvePath(execDir, scriptPath),
+			trigger:     trigger,
+			description: cfg.Description,
+			schedule:    schedule,
+		}
+
+		log.Printf("Starting schedule job %s with cron %q", jobCfg.name, jobCfg.trigger.Value)
+		go runScheduleJob(jobCfg)
+	}
+
+	return firstErr
+}
+
+func runScheduleJob(cfg scheduleJobConfig) {
+	for {
+		next := cfg.schedule.next(time.Now())
+		if next.IsZero() {
+			log.Printf("Schedule job %s has no next run time", cfg.name)
+			return
+		}
+
+		log.Printf("Schedule job %s next run at %s", cfg.name, next.Format(time.RFC3339))
+		timer := time.NewTimer(time.Until(next))
+		<-timer.C
+
+		allParams := map[string]interface{}{
+			"api":                        cfg.name,
+			"nyan_job_name":              cfg.name,
+			"nyan_schedule_trigger_type": cfg.trigger.Type,
+			"nyan_schedule_trigger":      cfg.trigger.Value,
+			"nyan_schedule_time":         next.Format(time.RFC3339),
+			"nyan_schedule_description":  cfg.description,
+		}
+		result, err := runJavaScript(cfg.scriptPath, "", allParams)
+		if err != nil {
+			log.Printf("Schedule job %s failed: %v", cfg.name, err)
+			continue
+		}
+		log.Printf("Schedule job %s completed: %s", cfg.name, result)
+	}
 }
 
 // connectURL が env:XXXX 形式なら環境変数 XXXX で解決する。空や未設定はエラー。
@@ -1588,6 +1853,9 @@ func cp932ToUTF8(data []byte) (string, error) {
 func handleNyan(c *gin.Context) {
 	apis := make(map[string]ApiData)
 	for apiName, cfg := range apiConfig {
+		if strings.TrimSpace(cfg.Type) == apiTypeSchedule {
+			continue
+		}
 		apis[apiName] = ApiData{
 			Description: cfg.Description,
 			Push:        cfg.Push,
@@ -1695,6 +1963,10 @@ func handleJSONRPC(c *gin.Context) {
 	// 3) api.json から、リクエストされたAPI設定を取得
 	config, exists := apiConfig[rpcReq.Method]
 	if !exists {
+		respondJSONRPCError(c, rpcReq.ID, -32601, fmt.Sprintf("API not found: %s", rpcReq.Method), nil)
+		return
+	}
+	if strings.TrimSpace(config.Type) == apiTypeSchedule {
 		respondJSONRPCError(c, rpcReq.ID, -32601, fmt.Sprintf("API not found: %s", rpcReq.Method), nil)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ type JSONRPCError struct {
 var globalConfig Config
 
 // ビルド時に -ldflags "-X main.buildVersion=..." で上書き可能
-var buildVersion = "v0.0.12"
+var buildVersion = "v0.0.13"
 
 // api.jsonから取得する設定
 var apiConfig APIConfig


### PR DESCRIPTION
feature/v0.0.13 を main に取り込み

feature/v0.0.13 の変更を main にマージ。
Go 1.26 対応に加えて、public フォルダ公開、paramCheck / outCheck、拡張レスポンス形式、schedule 定期実行機能を反映。

api.json のサンプル定義と JavaScript サンプルを追加し、README に各機能の設定方法、実行時パラメータ、予約語の説明を追記。
