### PR TITLE
v0.0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NYAN_API_PATH=/path/to/api.json NYAN_CONFIG_PATH=/path/to/config.json ./NyanPUI_
 
 CLI オプションと環境変数には絶対パス、または NyanPUI を起動したカレントディレクトリからの相対パスを指定できます。指定したファイルが存在しない場合、またはディレクトリを指定した場合は起動時にエラーになります。
 
-`api.json` 内の `script` / `html` / `path` / `paramCheck` / `outCheck` の相対パスは、`api.json` が置かれているディレクトリから解決されます。
+各 `api.json` 内の `script` / `html` / `path` / `paramCheck` / `outCheck` の相対パスは、その定義を書いた `api.json` が置かれているディレクトリから解決されます。
 `config.json` 内の `certPath` / `keyPath` / `javascript_include` / `log.Filename` の相対パスは、`config.json` が置かれているディレクトリから解決されます。
 
 起動時のログには、読み込んだ `config.json` / `api.json` の絶対パスと、その指定元（`--api`, `--config`, 環境変数, default）が出力されます。`/css`, `/images`, `/js`, `/favicon.ico` の組み込み静的ファイルは、設定ファイルの場所に関係なく実行ファイルと同じディレクトリの `html/` 配下から配信されます。
@@ -100,9 +100,9 @@ CLI オプションと環境変数には絶対パス、または NyanPUI を起�
 
 ### api.json のホットリロード
 
-`api.json` は既定で1秒ごとに確認され、内容のSHA-256が変化した場合だけ再読み込みされます。`APIHotReload.Enabled` を `false` にすると無効化できます。`Interval` は `500ms`、`1s`、`1m`、`24h` などのGo duration形式で指定し、省略時は `1s` です。0以下または解析できない値は起動エラーになります。
+ルートの `api.json` と、そこからincludeされたすべての `api.json` は既定で1秒ごとに確認され、いずれかの内容が変化した場合にルートから再読み込みされます。`APIHotReload.Enabled` を `false` にすると無効化できます。`Interval` は `500ms`、`1s`、`1m`、`24h` などのGo duration形式で指定し、省略時は `1s` です。0以下または解析できない値は起動エラーになります。
 
-再読み込みではJSON全体と、すべての `schedule` / `ws_client` 定義を事前検証します。正常な候補だけが一括で公開され、不正な内容の場合は直前の正常な定義を維持します。同じ不正内容は変更されるまで再解析・再出力しません。
+再読み込みではincludeグラフ全体と、すべての `schedule` / `ws_client` 定義を事前検証します。正常な候補だけが一括で公開され、不正な内容の場合は直前の正常な定義を維持します。存在しないinclude候補も監視され、ファイルを作成・修正すると自動復旧します。同じ不正内容のログは状態が変わるまで重複出力しません。
 
 追加、変更、削除は通常API、HTML API、public API、`/nyan`、JSON-RPC、`nyanCallMe`、WebSocket受信処理、pushへ次の処理から反映されます。`schedule` と `ws_client` も動的に開始、更新、停止します。既存のWebSocketサーバー接続は設定変更だけでは切断されません。`ws_client` はscriptまたはdescriptionだけの変更では接続を維持し、`connectURL` の変更時だけ接続先を切り替えます。
 
@@ -157,7 +157,22 @@ CLI オプションと環境変数には絶対パス、または NyanPUI を起�
 
 省略可能なフィールド: `type`, `script`, `html`, `path`, `connectURL`, `trigger`, `paramCheck`, `outCheck`, `description`, `push`。
 
-`paramCheck` は `paramcheck`、`outCheck` は `outcheck` の小文字表記でも読み込めます。README では `paramCheck` / `outCheck` を推奨表記とします。
+`paramCheck` は `paramcheck` / `check`、`outCheck` は `outcheck` の別名でも読み込めます。README では `paramCheck` / `outCheck` を推奨表記とします。
+
+### api.jsonの分割と多段include
+
+`type: "include"` を使うとAPI定義を複数ファイルに分割できます。includeのキーがマウント名となり、子ファイルのAPIは `/` 区切りの完全名で公開されます。
+
+```json
+{
+  "health": {"script": "./javascript/health.js"},
+  "sub": {"type": "include", "path": "./sub/api.json"}
+}
+```
+
+子の `sub/api.json` に `getItem` と、さらに `admin` includeがある場合、API名は `sub/getItem`、`sub/admin/...` となります。完全名はHTTP、WebSocket、JSON-RPC、`nyanCallMe`、push、public、schedule、ws_clientで共通です。
+
+include定義に指定できるフィールドは`type`と`path`だけです。循環参照、展開後の重複名、重複JSONキー、マウント名の衝突や `/` を含む不正なマウント名は読み込みエラーになります。includeされない既存API名に `/` を含める書き方は引き続き利用できます。
 
 通常 API は `GET`, `POST`, `PUT`, `DELETE` などのメソッドを受け付けます。`Content-Type: application/json` の JSON body、フォーム値、URL クエリを `nyanAllParams` にまとめて渡します。`api` が未指定の場合は、エンドポイントパスまたは `html` が入ります。
 
@@ -331,6 +346,35 @@ return {
 };
 ```
 
+### `/nyan`と入出力スキーマ
+
+`GET /nyan`または`GET /nyan/`は通常APIだけを一覧表示します。`public`、`schedule`、`ws_client`は含まれません。`GET /nyan/{API名}`では通常APIの詳細と`inputSchema`、`outputSchema`、`schemaSource`を返します。includeされたAPIも`/nyan/sub/admin/getItem`のような完全名で取得できます。
+
+入力スキーマは`paramCheck`のトップレベルに`nyanInputSchema`、出力スキーマは`outCheck`に`nyanOutputSchema`として宣言します。
+
+```js
+const nyanInputSchema = {
+  type: "object",
+  properties: {id: {type: "integer"}},
+  required: ["id"],
+  additionalProperties: false
+};
+```
+
+```js
+const nyanOutputSchema = {
+  type: "object",
+  properties: {status: {const: 200}},
+  required: ["status"]
+};
+```
+
+入力は`nyanInputSchema`、本体scriptの旧形式`nyanAcceptedParams`、空スキーマの順で解決します。出力は`nyanOutputSchema`、空スキーマの順です。legacy入力を利用した場合は互換性のため`nyanAcceptedParams`も返します。`nyanOutputColumns`は公開しません。
+
+スキーマはJavaScriptを実行せずASTから静的に読み取ります。オブジェクト、配列、文字列、数値、真偽値、`null`を利用できます。関数呼び出し、spread、識別子参照などの動的な定義はスキーマ解決エラーになります。スキーマファイルは詳細リクエストごとに読み直されます。
+
+公開したJSON Schemaによるリクエスト・レスポンスの自動検証は行いません。実際の検証は従来どおり`paramCheck`と`outCheck`が担当します。
+
 ### WebSocket レシーバー（`type: "ws_client"`）
 
 `type: "ws_client"` を指定すると NyanPUI 自身が WebSocket クライアントになり、起動時に常時接続します（HTTP エンドポイントとしては登録されません）。
@@ -416,7 +460,7 @@ schedule の `script` では通常 API と同じ Goja 環境を使えます。�
 
 * `config.json` と `api.json` を編集後、実行ファイルを起動。設定ファイルを別の場所に置く場合は `--api` / `--config`、または `NYAN_API_PATH` / `NYAN_CONFIG_PATH` で指定します。
 * デフォルトで [http://localhost:8009/](http://localhost:8009/) にアクセスするとサンプルが表示されます。 Windows MacOS Linuxで実行可能です。 各自でビルドいただくか、[リリース](https://github.com/NyanQL/NyanPUI/releases)からダウンロードしてください。
-* `/nyan` にアクセスすると、`type: "schedule"` 以外の API 一覧を JSON で取得できます。
+* `/nyan` にアクセスすると通常APIの一覧を、`/nyan/{API名}`では入出力スキーマを含む詳細をJSONで取得できます。
 * `/css`, `/images`, `/js`, `/favicon.ico` は `html/` 配下の静的ファイルとして配信されます。
 
 ## ビルド

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ CLI オプションと環境変数には絶対パス、または NyanPUI を起�
   "javascript_include": [
     "javascript/lib/nyanPlateToJson.js"
   ],
+  "APIHotReload": {
+    "Enabled": true,
+    "Interval": "1s"
+  },
   "log": {
     "Filename": "./logs/nyanpui.log",
     "MaxSize": 5,
@@ -93,6 +97,14 @@ CLI オプションと環境変数には絶対パス、または NyanPUI を起�
   }
 }
 ```
+
+### api.json のホットリロード
+
+`api.json` は既定で1秒ごとに確認され、内容のSHA-256が変化した場合だけ再読み込みされます。`APIHotReload.Enabled` を `false` にすると無効化できます。`Interval` は `500ms`、`1s`、`1m`、`24h` などのGo duration形式で指定し、省略時は `1s` です。0以下または解析できない値は起動エラーになります。
+
+再読み込みではJSON全体と、すべての `schedule` / `ws_client` 定義を事前検証します。正常な候補だけが一括で公開され、不正な内容の場合は直前の正常な定義を維持します。同じ不正内容は変更されるまで再解析・再出力しません。
+
+追加、変更、削除は通常API、HTML API、public API、`/nyan`、JSON-RPC、`nyanCallMe`、WebSocket受信処理、pushへ次の処理から反映されます。`schedule` と `ws_client` も動的に開始、更新、停止します。既存のWebSocketサーバー接続は設定変更だけでは切断されません。`ws_client` はscriptまたはdescriptionだけの変更では接続を維持し、`connectURL` の変更時だけ接続先を切り替えます。
 
 ### ログ設定（例）
 

--- a/config.json
+++ b/config.json
@@ -17,5 +17,9 @@
     "MaxAge": 7,
     "Compress": true,
     "EnableLogging": false
+  },
+  "APIHotReload": {
+    "Enabled": true,
+    "Interval": "1s"
   }
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
@@ -13,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -30,14 +33,15 @@ import (
 
 // Config は設定データを表します。
 type Config struct {
-	Name              string    `json:"name"`
-	Profile           string    `json:"profile"`
-	Version           string    `json:"version"`
-	Port              int       `json:"port"`
-	CertFile          string    `json:"certPath"`
-	KeyFile           string    `json:"keyPath"`
-	JavaScriptInclude []string  `json:"javascript_include"`
-	Log               LogConfig `json:"log"`
+	Name              string             `json:"name"`
+	Profile           string             `json:"profile"`
+	Version           string             `json:"version"`
+	Port              int                `json:"port"`
+	CertFile          string             `json:"certPath"`
+	KeyFile           string             `json:"keyPath"`
+	JavaScriptInclude []string           `json:"javascript_include"`
+	Log               LogConfig          `json:"log"`
+	APIHotReload      APIHotReloadConfig `json:"APIHotReload"`
 }
 
 // LogConfig はログ設定を表します。
@@ -174,7 +178,11 @@ type serviceFilePaths struct {
 }
 
 // api.jsonから取得する設定
-var apiConfig APIConfig
+var (
+	apiConfigMu        sync.RWMutex
+	apiConfig          APIConfig
+	backgroundRuntimes *backgroundRuntimeManager
+)
 
 // ストレージ
 var storage = make(map[string]string)
@@ -219,6 +227,10 @@ func main() {
 	apiBaseDir := filepath.Dir(paths.API.Path)
 	adjustConfigPaths(configBaseDir, &config)
 	globalConfig = config
+	apiHotReloadInterval, err := parseAPIHotReloadInterval(config.APIHotReload.Interval)
+	if err != nil {
+		log.Fatalf("Invalid APIHotReload.Interval %q: %v", config.APIHotReload.Interval, err)
+	}
 
 	// ログ設定を初期化
 	if globalConfig.Log.EnableLogging {
@@ -243,16 +255,27 @@ func main() {
 	log.Printf("API file: %s (source: %s)", paths.API.Path, paths.API.Source)
 	log.Printf("Config version: %s", globalConfig.Version)
 
-	// API設定をロード
-	if err := loadAPIConfig(paths.API.Path, apiBaseDir); err != nil {
+	// API設定をロードし、background定義を公開前に全件検証する。
+	initialConfig, initialHash, err := readAPIConfigFile(paths.API.Path, apiBaseDir)
+	if err != nil {
 		log.Fatal("Error loading API configuration:", err)
 	}
-
-	if err := startWebSocketClients(exeDir); err != nil {
-		log.Printf("Failed to start WebSocket clients: %v", err)
+	initialSchedules, err := buildScheduleJobConfigs(initialConfig)
+	if err != nil {
+		log.Fatal("Error loading schedule configuration:", err)
 	}
-	if err := startScheduleJobs(exeDir); err != nil {
-		log.Printf("Failed to start schedule jobs: %v", err)
+	initialWSClients, err := buildWSClientConfigs(initialConfig)
+	if err != nil {
+		log.Fatal("Error loading WebSocket client configuration:", err)
+	}
+	setAPIConfig(initialConfig)
+	backgroundRuntimes = newBackgroundRuntimeManager()
+	backgroundRuntimes.reconcile(initialSchedules, initialWSClients)
+	if config.APIHotReload.Enabled {
+		log.Printf("API hot reload enabled: interval=%s", apiHotReloadInterval)
+		go watchAPIConfig(paths.API.Path, apiBaseDir, apiHotReloadInterval, initialHash)
+	} else {
+		log.Printf("API hot reload disabled")
 	}
 
 	gin.DisableConsoleColor()
@@ -267,33 +290,11 @@ func main() {
 	r.GET("/nyan", handleNyan)
 	r.POST("/nyan-rpc", handleJSONRPC)
 
-	// 各APIエンドポイントを設定
-	for endpoint := range apiConfig {
-		config := apiConfig[endpoint] // ループ変数をローカル変数にコピー
-		switch strings.TrimSpace(config.Type) {
-		case apiTypeWSClient:
-			continue
-		case apiTypeSchedule:
-			continue
-		case apiTypePublic:
-			registerPublicEndpoint(r, endpoint, config, exeDir)
-			continue
-		}
-		r.Any("/"+endpoint, func(c *gin.Context) {
-			handleAPIRequestOrWebSocket(c, config)
-		})
-	}
-
 	r.Any("/", func(c *gin.Context) {
 		// クエリパラメータ "api" をチェック
 		apiName := c.Query("api")
 		if apiName != "" {
-			if config, ok := apiConfig[apiName]; ok {
-				if strings.TrimSpace(config.Type) == apiTypeSchedule {
-					c.JSON(http.StatusNotFound, gin.H{"error": "API not found"})
-					return
-				}
-				handleAPIRequestOrWebSocket(c, config)
+			if handleAPIRequestOrWebSocket(c, apiName) {
 				return
 			} else {
 				c.JSON(http.StatusNotFound, gin.H{"error": "API not found"})
@@ -301,7 +302,16 @@ func main() {
 			}
 		}
 		// "api" パラメータがなければ、デフォルトで "html" を使用
-		handleAPIRequestOrWebSocket(c, apiConfig["html"])
+		if !handleAPIRequestOrWebSocket(c, "html") {
+			c.JSON(http.StatusNotFound, gin.H{"error": "API not found"})
+		}
+	})
+
+	r.NoRoute(func(c *gin.Context) {
+		if dispatchDynamicEndpoint(c) {
+			return
+		}
+		c.JSON(http.StatusNotFound, gin.H{"error": "API not found"})
 	})
 
 	// HTTPSサーバーを起動するかどうかを判断
@@ -404,6 +414,7 @@ func adjustConfigPaths(configBaseDir string, config *Config) {
 // loadConfig は設定ファイルを読み込みます。
 func loadConfig(filename string) (Config, error) {
 	var config Config
+	applyConfigDefaults(&config)
 
 	// 設定ファイルを読み込む
 	data, err := os.ReadFile(filename)
@@ -420,35 +431,37 @@ func loadConfig(filename string) (Config, error) {
 
 // apiの設定を読み込みます。
 func loadAPIConfig(filePath string, apiBaseDir string) error {
-	data, err := os.ReadFile(filePath)
+	config, _, err := readAPIConfigFile(filePath, apiBaseDir)
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, &apiConfig); err != nil {
-		return err
-	}
-	adjustAPIConfigPaths(apiBaseDir)
+	setAPIConfig(config)
 	return nil
 }
 
-func adjustAPIConfigPaths(apiBaseDir string) {
-	for apiKey, endpoint := range apiConfig {
+func adjustAPIConfigPaths(config APIConfig, apiBaseDir string) {
+	for apiKey, endpoint := range config {
 		endpoint.Script = resolvePathFromBase(apiBaseDir, endpoint.Script)
 		endpoint.HTML = resolvePathFromBase(apiBaseDir, endpoint.HTML)
 		endpoint.Path = resolvePathFromBase(apiBaseDir, endpoint.Path)
 		endpoint.ParamCheck = resolvePathFromBase(apiBaseDir, endpoint.ParamCheck)
 		endpoint.OutCheck = resolvePathFromBase(apiBaseDir, endpoint.OutCheck)
-		apiConfig[apiKey] = endpoint
+		config[apiKey] = endpoint
 	}
 }
 
 // handleAPIRequestOrWebSocket はAPIリクエストまたはWebSocketリクエストを処理します。
-func handleAPIRequestOrWebSocket(c *gin.Context, config EndpointConfig) {
+func handleAPIRequestOrWebSocket(c *gin.Context, apiName string) bool {
+	config, ok := currentAPIConfig()[apiName]
+	if !ok || !isRequestAPI(config) {
+		return false
+	}
 	if websocket.IsWebSocketUpgrade(c.Request) {
-		handleWebSocket(c, config)
+		handleWebSocket(c, apiName, config)
 	} else {
 		handleAPIRequest(c, config)
 	}
+	return true
 }
 
 // handleAPIRequest はAPIリクエストを処理します。
@@ -534,8 +547,7 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 }
 
 // handleWebSocket はWebSocketリクエストを処理します。
-func handleWebSocket(c *gin.Context, config EndpointConfig) {
-	endpoint := c.Request.URL.Path[1:] // 例: "/html2" -> "html2"
+func handleWebSocket(c *gin.Context, endpoint string, config EndpointConfig) {
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		log.Printf("Failed to set websocket upgrade: %v", err)
@@ -582,7 +594,7 @@ func handleWebSocket(c *gin.Context, config EndpointConfig) {
 		// "api" キーがあるかチェック
 		if apiName, ok := req["api"]; ok {
 			// apiConfig から対象の設定を取得
-			apiCfg, found := apiConfig[apiName]
+			apiCfg, found := currentAPIConfig()[apiName]
 			if !found {
 				errMsg := fmt.Sprintf("API %s not found", apiName)
 				conn.WriteMessage(messageType, []byte(errMsg))
@@ -663,7 +675,7 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (interf
 		return nil, fmt.Errorf("api name is required")
 	}
 
-	apiCfg, found := apiConfig[apiName]
+	apiCfg, found := currentAPIConfig()[apiName]
 	if !found {
 		return nil, fmt.Errorf("API config not found: %s", apiName)
 	}
@@ -1075,6 +1087,96 @@ const (
 	apiTypeSchedule = "schedule"
 )
 
+func isRequestAPI(config EndpointConfig) bool {
+	switch strings.TrimSpace(config.Type) {
+	case apiTypeWSClient, apiTypePublic, apiTypeSchedule:
+		return false
+	default:
+		return true
+	}
+}
+
+// dispatchDynamicEndpoint resolves the request against one immutable API snapshot.
+func dispatchDynamicEndpoint(c *gin.Context) bool {
+	requestPath := strings.TrimPrefix(c.Request.URL.Path, "/")
+	config := currentAPIConfig()
+	if endpoint, ok := config[requestPath]; ok && isRequestAPI(endpoint) {
+		if websocket.IsWebSocketUpgrade(c.Request) {
+			handleWebSocket(c, requestPath, endpoint)
+		} else {
+			handleAPIRequest(c, endpoint)
+		}
+		return true
+	}
+
+	endpointName := ""
+	var endpoint EndpointConfig
+	for name, candidate := range config {
+		if strings.TrimSpace(candidate.Type) != apiTypePublic {
+			continue
+		}
+		cleanName := strings.Trim(strings.TrimSpace(name), "/")
+		if requestPath == cleanName || strings.HasPrefix(requestPath, cleanName+"/") {
+			if len(cleanName) > len(endpointName) {
+				endpointName, endpoint = cleanName, candidate
+			}
+		}
+	}
+	if endpointName == "" {
+		return false
+	}
+	servePublicEndpoint(c, endpointName, endpoint)
+	return true
+}
+
+func servePublicEndpoint(c *gin.Context, endpoint string, config EndpointConfig) {
+	publicPath := strings.TrimSpace(config.Path)
+	if publicPath == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "public path is missing"})
+		return
+	}
+	requestPath := strings.TrimPrefix(c.Request.URL.Path, "/")
+	requestedPath := strings.TrimPrefix(strings.TrimPrefix(requestPath, endpoint), "/")
+	allParams, err := collectRequestParams(c, endpoint)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON data"})
+		return
+	}
+	allParams["nyan_public_endpoint"] = endpoint
+	allParams["nyan_public_path"] = requestedPath
+	ginContext = c
+	defer func() { ginContext = nil }()
+	if allowed, handled := runParamCheck(c, config, filepath.Dir(publicPath), "", allParams); handled || !allowed {
+		return
+	}
+	if requestedPath == "" || !filepath.IsLocal(requestedPath) {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	filePath := filepath.Join(publicPath, requestedPath)
+	info, err := os.Stat(filePath)
+	if err != nil || info.IsDir() {
+		if err != nil && !os.IsNotExist(err) {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read public file"})
+		} else {
+			c.Status(http.StatusNotFound)
+		}
+		return
+	}
+	if strings.TrimSpace(config.OutCheck) != "" {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read public file"})
+			return
+		}
+		response := APIResponse{Status: http.StatusOK, ContentType: http.DetectContentType(content), Headers: map[string]string{}, Body: content}
+		if runOutCheck(c, config, filepath.Dir(publicPath), "", allParams, response) {
+			return
+		}
+	}
+	c.File(filePath)
+}
+
 func registerPublicEndpoint(r *gin.Engine, endpoint string, config EndpointConfig, exeDir string) {
 	routePath := "/" + strings.Trim(strings.TrimSpace(endpoint), "/")
 	if routePath == "/" {
@@ -1328,89 +1430,6 @@ func (s cronSchedule) matches(t time.Time) bool {
 		s.months[int(t.Month())]
 }
 
-func startScheduleJobs(execDir string) error {
-	var firstErr error
-	for name, cfg := range apiConfig {
-		if strings.TrimSpace(cfg.Type) != apiTypeSchedule {
-			continue
-		}
-
-		scriptPath := strings.TrimSpace(cfg.Script)
-		trigger := cfg.Trigger
-		trigger.Type = strings.TrimSpace(trigger.Type)
-		trigger.Value = strings.TrimSpace(trigger.Value)
-
-		if scriptPath == "" {
-			err := fmt.Errorf("schedule %s: script is missing", name)
-			log.Print(err)
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		if trigger.Type != "cron" {
-			err := fmt.Errorf("schedule %s: unsupported trigger type %q", name, trigger.Type)
-			log.Print(err)
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-
-		schedule, err := parseCronSchedule(trigger.Value)
-		if err != nil {
-			err = fmt.Errorf("schedule %s: invalid cron trigger %q: %w", name, trigger.Value, err)
-			log.Print(err)
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-
-		jobCfg := scheduleJobConfig{
-			name:        name,
-			scriptPath:  resolvePath(execDir, scriptPath),
-			trigger:     trigger,
-			description: cfg.Description,
-			schedule:    schedule,
-		}
-
-		log.Printf("Starting schedule job %s with cron %q", jobCfg.name, jobCfg.trigger.Value)
-		go runScheduleJob(jobCfg)
-	}
-
-	return firstErr
-}
-
-func runScheduleJob(cfg scheduleJobConfig) {
-	for {
-		next := cfg.schedule.next(time.Now())
-		if next.IsZero() {
-			log.Printf("Schedule job %s has no next run time", cfg.name)
-			return
-		}
-
-		log.Printf("Schedule job %s next run at %s", cfg.name, next.Format(time.RFC3339))
-		timer := time.NewTimer(time.Until(next))
-		<-timer.C
-
-		allParams := map[string]interface{}{
-			"api":                        cfg.name,
-			"nyan_job_name":              cfg.name,
-			"nyan_schedule_trigger_type": cfg.trigger.Type,
-			"nyan_schedule_trigger":      cfg.trigger.Value,
-			"nyan_schedule_time":         next.Format(time.RFC3339),
-			"nyan_schedule_description":  cfg.description,
-		}
-		result, err := runJavaScript(cfg.scriptPath, "", allParams)
-		if err != nil {
-			log.Printf("Schedule job %s failed: %v", cfg.name, err)
-			continue
-		}
-		log.Printf("Schedule job %s completed: %s", cfg.name, result)
-	}
-}
-
 // connectURL が env:XXXX 形式なら環境変数 XXXX で解決する。空や未設定はエラー。
 func resolveConnectURL(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
@@ -1429,133 +1448,6 @@ func resolveConnectURL(raw string) (string, error) {
 		return val, nil
 	}
 	return raw, nil
-}
-
-// startWebSocketClients は api.json に定義された ws_client を起動します。
-func startWebSocketClients(execDir string) error {
-	var firstErr error
-	for name, cfg := range apiConfig {
-		if strings.TrimSpace(cfg.Type) != apiTypeWSClient {
-			continue
-		}
-
-		scriptPath := strings.TrimSpace(cfg.Script)
-		connectURLRaw := strings.TrimSpace(cfg.ConnectURL)
-
-		if scriptPath == "" {
-			err := fmt.Errorf("ws_client %s: script is missing", name)
-			log.Print(err)
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		if connectURLRaw == "" {
-			err := fmt.Errorf("ws_client %s: connectURL is missing", name)
-			log.Print(err)
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-
-		connectURL, err := resolveConnectURL(connectURLRaw)
-		if err != nil {
-			log.Printf("ws_client %s: %v", name, err)
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-
-		wsCfg := wsClientConfig{
-			name:        name,
-			scriptPath:  scriptPath,
-			connectURL:  connectURL,
-			description: cfg.Description,
-		}
-
-		log.Printf("Starting WebSocket client %s -> %s", wsCfg.name, wsCfg.connectURL)
-		go runWebSocketClient(wsCfg)
-	}
-
-	return firstErr
-}
-
-// 常時接続を維持し、切断時は指数バックオフで再接続します。
-func runWebSocketClient(cfg wsClientConfig) {
-	backoff := time.Second
-	for {
-		err := connectAndListenWebSocket(cfg)
-		if err != nil {
-			log.Printf("WebSocket client %s disconnected: %v", cfg.name, err)
-		}
-
-		time.Sleep(backoff)
-		if backoff < 30*time.Second {
-			backoff *= 2
-			if backoff > 30*time.Second {
-				backoff = 30 * time.Second
-			}
-		}
-	}
-}
-
-func connectAndListenWebSocket(cfg wsClientConfig) error {
-	conn, _, err := websocket.DefaultDialer.Dial(cfg.connectURL, nil)
-	if err != nil {
-		return fmt.Errorf("dial failed: %w", err)
-	}
-	defer conn.Close()
-
-	log.Printf("WebSocket client %s connected", cfg.name)
-
-	for {
-		msgType, data, err := conn.ReadMessage()
-		if err != nil {
-			return fmt.Errorf("read error: %w", err)
-		}
-		if msgType == websocket.CloseMessage {
-			return fmt.Errorf("close message received: %s", string(data))
-		}
-
-		log.Printf("ws_client %s received %s: %s", cfg.name, websocketMessageTypeLabel(msgType), string(data))
-
-		allParams := map[string]interface{}{
-			"api":             cfg.name,
-			"ws_client":       cfg.name,
-			"ws_message_type": websocketMessageTypeLabel(msgType),
-			"ws_message_text": string(data),
-			"ws_connect_url":  cfg.connectURL,
-			"ws_description":  cfg.description,
-		}
-
-		if msgType == websocket.BinaryMessage {
-			allParams["ws_message_base64"] = base64.StdEncoding.EncodeToString(data)
-		}
-
-		if msgType == websocket.TextMessage {
-			var decoded interface{}
-			if err := json.Unmarshal(data, &decoded); err == nil {
-				allParams["ws_message_json"] = decoded
-			}
-		}
-
-		result, err := runJavaScript(cfg.scriptPath, "", allParams)
-		if err != nil {
-			log.Printf("ws_client %s script error: %v", cfg.name, err)
-			continue
-		}
-
-		trimmed := strings.TrimSpace(result)
-		if trimmed == "" {
-			continue
-		}
-
-		if err := conn.WriteMessage(websocket.TextMessage, []byte(trimmed)); err != nil {
-			return fmt.Errorf("send error: %w", err)
-		}
-	}
 }
 
 func websocketMessageTypeLabel(t int) string {
@@ -1954,7 +1846,7 @@ func cp932ToUTF8(data []byte) (string, error) {
 // handleNyan は /nyan へのリクエストを処理します。
 func handleNyan(c *gin.Context) {
 	apis := make(map[string]ApiData)
-	for apiName, cfg := range apiConfig {
+	for apiName, cfg := range currentAPIConfig() {
 		if strings.TrimSpace(cfg.Type) == apiTypeSchedule {
 			continue
 		}
@@ -2063,7 +1955,7 @@ func handleJSONRPC(c *gin.Context) {
 	}
 
 	// 3) api.json から、リクエストされたAPI設定を取得
-	config, exists := apiConfig[rpcReq.Method]
+	config, exists := currentAPIConfig()[rpcReq.Method]
 	if !exists {
 		respondJSONRPCError(c, rpcReq.ID, -32601, fmt.Sprintf("API not found: %s", rpcReq.Method), nil)
 		return
@@ -2144,7 +2036,7 @@ func performPush(config EndpointConfig, allParams map[string]interface{}) {
 	if config.Push == "" {
 		return
 	}
-	pushConfig, ok := apiConfig[config.Push]
+	pushConfig, ok := currentAPIConfig()[config.Push]
 	if !ok {
 		log.Printf("Push target %s not found in apiConfig", config.Push)
 		return
@@ -2182,6 +2074,539 @@ func performPush(config EndpointConfig, allParams map[string]interface{}) {
 				log.Printf("Error pushing message to %s: %v", config.Push, err)
 			} else {
 				log.Printf("Push message sent to %s", config.Push)
+			}
+		}
+	}
+}
+
+const defaultAPIHotReloadCheckInterval = time.Second
+
+type APIHotReloadConfig struct {
+	Enabled  bool   `json:"Enabled"`
+	Interval string `json:"Interval"`
+}
+
+func applyConfigDefaults(target *Config) {
+	target.APIHotReload.Enabled = true
+	target.APIHotReload.Interval = defaultAPIHotReloadCheckInterval.String()
+}
+
+func parseAPIHotReloadInterval(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultAPIHotReloadCheckInterval, nil
+	}
+	interval, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, err
+	}
+	if interval <= 0 {
+		return 0, fmt.Errorf("must be greater than zero")
+	}
+	return interval, nil
+}
+
+func decodeAPIConfig(data []byte, apiBaseDir string) (APIConfig, error) {
+	var config APIConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("decode api JSON: %w", err)
+	}
+	if config == nil {
+		return nil, fmt.Errorf("decode api JSON: top-level value must be an object")
+	}
+	adjustAPIConfigPaths(config, apiBaseDir)
+	return config, nil
+}
+
+func readAPIConfigFile(path, apiBaseDir string) (APIConfig, [sha256.Size]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, [sha256.Size]byte{}, fmt.Errorf("read api file: %w", err)
+	}
+	hash := sha256.Sum256(data)
+	config, err := decodeAPIConfig(data, apiBaseDir)
+	return config, hash, err
+}
+
+func currentAPIConfig() APIConfig {
+	apiConfigMu.RLock()
+	config := apiConfig
+	apiConfigMu.RUnlock()
+	return config
+}
+
+func setAPIConfig(config APIConfig) {
+	apiConfigMu.Lock()
+	apiConfig = config
+	apiConfigMu.Unlock()
+}
+
+func reloadAPIConfigIfChanged(path, apiBaseDir string, lastHash [sha256.Size]byte) ([sha256.Size]byte, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return lastHash, false, fmt.Errorf("read api file: %w", err)
+	}
+	hash := sha256.Sum256(data)
+	if hash == lastHash {
+		return lastHash, false, nil
+	}
+	candidate, err := decodeAPIConfig(data, apiBaseDir)
+	if err != nil {
+		return hash, false, err
+	}
+	if reflect.DeepEqual(currentAPIConfig(), candidate) {
+		return hash, false, nil
+	}
+	schedules, err := buildScheduleJobConfigs(candidate)
+	if err != nil {
+		return hash, false, err
+	}
+	wsClients, err := buildWSClientConfigs(candidate)
+	if err != nil {
+		return hash, false, err
+	}
+	setAPIConfig(candidate)
+	if backgroundRuntimes != nil {
+		backgroundRuntimes.reconcile(schedules, wsClients)
+	}
+	return hash, true, nil
+}
+
+func watchAPIConfig(path, apiBaseDir string, interval time.Duration, initialHash [sha256.Size]byte) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	lastHash := initialHash
+	lastError := ""
+	for range ticker.C {
+		hash, reloaded, err := reloadAPIConfigIfChanged(path, apiBaseDir, lastHash)
+		lastHash = hash
+		if err != nil {
+			if err.Error() != lastError {
+				log.Printf("API hot reload failed: %v; current API configuration remains active", err)
+			}
+			lastError = err.Error()
+			continue
+		}
+		lastError = ""
+		if reloaded {
+			log.Printf("API hot reload succeeded: api_count=%d", len(currentAPIConfig()))
+		}
+	}
+}
+
+type backgroundRuntimeManager struct {
+	mu        sync.Mutex
+	schedules map[string]*scheduleRuntime
+	wsClients map[string]*wsClientRuntime
+}
+
+type scheduleRuntime struct {
+	mu      sync.Mutex
+	desired *scheduleJobConfig
+	wake    chan struct{}
+	done    chan struct{}
+	stopped bool
+}
+
+type wsClientRuntime struct {
+	mu         sync.Mutex
+	desired    *wsClientConfig
+	wake       chan struct{}
+	done       chan struct{}
+	stopped    bool
+	conn       *websocket.Conn
+	dialCancel context.CancelFunc
+}
+
+func newBackgroundRuntimeManager() *backgroundRuntimeManager {
+	return &backgroundRuntimeManager{schedules: make(map[string]*scheduleRuntime), wsClients: make(map[string]*wsClientRuntime)}
+}
+
+func (manager *backgroundRuntimeManager) reconcile(schedules map[string]scheduleJobConfig, wsClients map[string]wsClientConfig) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	for name, runtime := range manager.schedules {
+		if _, exists := schedules[name]; !exists {
+			if _, changed := runtime.update(nil); changed {
+				log.Printf("Stopping schedule job %s", name)
+			}
+		}
+	}
+	for name, cfg := range schedules {
+		if runtime, exists := manager.schedules[name]; exists {
+			if accepted, changed := runtime.update(&cfg); accepted {
+				if changed {
+					log.Printf("Updated schedule job %s with cron %q", name, cfg.trigger.Value)
+				}
+				continue
+			}
+		}
+		runtime := newScheduleRuntime(cfg)
+		manager.schedules[name] = runtime
+		log.Printf("Starting schedule job %s with cron %q", name, cfg.trigger.Value)
+		go manager.runSchedule(name, runtime)
+	}
+	for name, runtime := range manager.wsClients {
+		if _, exists := wsClients[name]; !exists {
+			if _, changed, _ := runtime.update(nil); changed {
+				log.Printf("Stopping WebSocket client %s", name)
+			}
+		}
+	}
+	for name, cfg := range wsClients {
+		if runtime, exists := manager.wsClients[name]; exists {
+			if accepted, changed, reconnect := runtime.update(&cfg); accepted {
+				if changed {
+					log.Printf("Updated WebSocket client %s reconnect=%t", name, reconnect)
+				}
+				continue
+			}
+		}
+		runtime := newWSClientRuntime(cfg)
+		manager.wsClients[name] = runtime
+		log.Printf("Starting WebSocket client %s -> %s", name, cfg.connectURL)
+		go manager.runWSClient(name, runtime)
+	}
+}
+
+func (manager *backgroundRuntimeManager) runSchedule(name string, runtime *scheduleRuntime) {
+	runtime.run()
+	manager.mu.Lock()
+	if manager.schedules[name] == runtime {
+		delete(manager.schedules, name)
+	}
+	manager.mu.Unlock()
+}
+
+func (manager *backgroundRuntimeManager) runWSClient(name string, runtime *wsClientRuntime) {
+	runtime.run()
+	manager.mu.Lock()
+	if manager.wsClients[name] == runtime {
+		delete(manager.wsClients, name)
+	}
+	manager.mu.Unlock()
+}
+
+func buildScheduleJobConfigs(config APIConfig) (map[string]scheduleJobConfig, error) {
+	result := make(map[string]scheduleJobConfig)
+	for name, endpoint := range config {
+		if strings.TrimSpace(endpoint.Type) != apiTypeSchedule {
+			continue
+		}
+		if strings.TrimSpace(endpoint.Script) == "" {
+			return nil, fmt.Errorf("schedule %s: script is missing", name)
+		}
+		trigger := endpoint.Trigger
+		trigger.Type, trigger.Value = strings.TrimSpace(trigger.Type), strings.TrimSpace(trigger.Value)
+		if trigger.Type != "cron" {
+			return nil, fmt.Errorf("schedule %s: unsupported trigger type %q", name, trigger.Type)
+		}
+		schedule, err := parseCronSchedule(trigger.Value)
+		if err != nil {
+			return nil, fmt.Errorf("schedule %s: invalid cron trigger %q: %w", name, trigger.Value, err)
+		}
+		result[name] = scheduleJobConfig{name: name, scriptPath: endpoint.Script, trigger: trigger, description: endpoint.Description, schedule: schedule}
+	}
+	return result, nil
+}
+
+func buildWSClientConfigs(config APIConfig) (map[string]wsClientConfig, error) {
+	result := make(map[string]wsClientConfig)
+	for name, endpoint := range config {
+		if strings.TrimSpace(endpoint.Type) != apiTypeWSClient {
+			continue
+		}
+		if strings.TrimSpace(endpoint.Script) == "" {
+			return nil, fmt.Errorf("ws_client %s: script is missing", name)
+		}
+		connectURL, err := resolveConnectURL(endpoint.ConnectURL)
+		if err != nil {
+			return nil, fmt.Errorf("ws_client %s: %w", name, err)
+		}
+		result[name] = wsClientConfig{name: name, scriptPath: endpoint.Script, connectURL: connectURL, description: endpoint.Description}
+	}
+	return result, nil
+}
+
+func signalRuntime(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+func newScheduleRuntime(cfg scheduleJobConfig) *scheduleRuntime {
+	copy := cfg
+	return &scheduleRuntime{desired: &copy, wake: make(chan struct{}, 1), done: make(chan struct{})}
+}
+
+func sameScheduleTiming(a, b scheduleJobConfig) bool {
+	return a.name == b.name && a.scriptPath == b.scriptPath && a.trigger == b.trigger
+}
+func sameScheduleConfig(a, b scheduleJobConfig) bool {
+	return sameScheduleTiming(a, b) && a.description == b.description
+}
+
+func (runtime *scheduleRuntime) update(cfg *scheduleJobConfig) (bool, bool) {
+	runtime.mu.Lock()
+	if runtime.stopped {
+		runtime.mu.Unlock()
+		return false, false
+	}
+	if cfg == nil {
+		if runtime.desired == nil {
+			runtime.mu.Unlock()
+			return true, false
+		}
+		runtime.desired = nil
+		runtime.mu.Unlock()
+		signalRuntime(runtime.wake)
+		return true, true
+	}
+	if runtime.desired != nil && sameScheduleConfig(*runtime.desired, *cfg) {
+		runtime.mu.Unlock()
+		return true, false
+	}
+	wake := runtime.desired == nil || !sameScheduleTiming(*runtime.desired, *cfg)
+	copy := *cfg
+	runtime.desired = &copy
+	runtime.mu.Unlock()
+	if wake {
+		signalRuntime(runtime.wake)
+	}
+	return true, true
+}
+
+func (runtime *scheduleRuntime) current(stop bool) (scheduleJobConfig, bool) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.desired == nil {
+		if stop {
+			runtime.stopped = true
+		}
+		return scheduleJobConfig{}, false
+	}
+	return *runtime.desired, true
+}
+
+func (runtime *scheduleRuntime) run() {
+	defer close(runtime.done)
+	for {
+		cfg, active := runtime.current(true)
+		if !active {
+			return
+		}
+		next := cfg.schedule.next(time.Now())
+		if next.IsZero() {
+			<-runtime.wake
+			continue
+		}
+		timer := time.NewTimer(time.Until(next))
+		select {
+		case <-runtime.wake:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			continue
+		case <-timer.C:
+		}
+		latest, active := runtime.current(false)
+		if !active || !sameScheduleTiming(cfg, latest) {
+			continue
+		}
+		params := map[string]interface{}{"api": latest.name, "nyan_job_name": latest.name, "nyan_schedule_trigger_type": latest.trigger.Type, "nyan_schedule_trigger": latest.trigger.Value, "nyan_schedule_time": next.Format(time.RFC3339), "nyan_schedule_description": latest.description}
+		if result, err := runJavaScript(latest.scriptPath, "", params); err != nil {
+			log.Printf("Schedule job %s failed: %v", latest.name, err)
+		} else {
+			log.Printf("Schedule job %s completed: %s", latest.name, result)
+		}
+	}
+}
+
+func newWSClientRuntime(cfg wsClientConfig) *wsClientRuntime {
+	copy := cfg
+	return &wsClientRuntime{desired: &copy, wake: make(chan struct{}, 1), done: make(chan struct{})}
+}
+
+func (runtime *wsClientRuntime) update(cfg *wsClientConfig) (bool, bool, bool) {
+	runtime.mu.Lock()
+	if runtime.stopped {
+		runtime.mu.Unlock()
+		return false, false, false
+	}
+	if cfg == nil {
+		if runtime.desired == nil {
+			runtime.mu.Unlock()
+			return true, false, false
+		}
+		runtime.desired = nil
+		conn, cancel := runtime.conn, runtime.dialCancel
+		runtime.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		if conn != nil {
+			_ = conn.Close()
+		}
+		signalRuntime(runtime.wake)
+		return true, true, false
+	}
+	if runtime.desired != nil && *runtime.desired == *cfg {
+		runtime.mu.Unlock()
+		return true, false, false
+	}
+	reconnect := runtime.desired == nil || runtime.desired.connectURL != cfg.connectURL
+	copy := *cfg
+	runtime.desired = &copy
+	conn, cancel := runtime.conn, runtime.dialCancel
+	runtime.mu.Unlock()
+	if reconnect {
+		if cancel != nil {
+			cancel()
+		}
+		if conn != nil {
+			_ = conn.Close()
+		}
+		signalRuntime(runtime.wake)
+	}
+	return true, true, reconnect
+}
+
+func (runtime *wsClientRuntime) current(stop bool) (wsClientConfig, bool) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.desired == nil {
+		if stop {
+			runtime.stopped = true
+		}
+		return wsClientConfig{}, false
+	}
+	return *runtime.desired, true
+}
+
+func (runtime *wsClientRuntime) beginDial(cfg wsClientConfig) (context.Context, context.CancelFunc, bool) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.stopped || runtime.desired == nil || runtime.desired.connectURL != cfg.connectURL {
+		return nil, nil, false
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runtime.dialCancel = cancel
+	return ctx, cancel, true
+}
+
+func (runtime *wsClientRuntime) finishDial(cancel context.CancelFunc) {
+	runtime.mu.Lock()
+	runtime.dialCancel = nil
+	runtime.mu.Unlock()
+	cancel()
+}
+func (runtime *wsClientRuntime) acceptConnection(conn *websocket.Conn, url string) bool {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.stopped || runtime.desired == nil || runtime.desired.connectURL != url {
+		return false
+	}
+	runtime.conn = conn
+	return true
+}
+func (runtime *wsClientRuntime) clearConnection(conn *websocket.Conn) {
+	runtime.mu.Lock()
+	if runtime.conn == conn {
+		runtime.conn = nil
+	}
+	runtime.mu.Unlock()
+}
+
+func (runtime *wsClientRuntime) run() {
+	defer close(runtime.done)
+	backoff := time.Second
+	for {
+		cfg, active := runtime.current(true)
+		if !active {
+			return
+		}
+		err := runtime.connectAndListen(cfg)
+		latest, active := runtime.current(true)
+		if !active {
+			return
+		}
+		if latest.connectURL != cfg.connectURL {
+			select {
+			case <-runtime.wake:
+			default:
+			}
+			backoff = time.Second
+			continue
+		}
+		if err != nil {
+			log.Printf("WebSocket client %s disconnected: %v", cfg.name, err)
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-runtime.wake:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			backoff = time.Second
+		case <-timer.C:
+			backoff *= 2
+			if backoff > 30*time.Second {
+				backoff = 30 * time.Second
+			}
+		}
+	}
+}
+
+func (runtime *wsClientRuntime) connectAndListen(cfg wsClientConfig) error {
+	ctx, cancel, ok := runtime.beginDial(cfg)
+	if !ok {
+		return nil
+	}
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, cfg.connectURL, nil)
+	runtime.finishDial(cancel)
+	if err != nil {
+		return fmt.Errorf("dial failed: %w", err)
+	}
+	if !runtime.acceptConnection(conn, cfg.connectURL) {
+		_ = conn.Close()
+		return nil
+	}
+	defer runtime.clearConnection(conn)
+	defer conn.Close()
+	for {
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("read error: %w", err)
+		}
+		latest, active := runtime.current(false)
+		if !active || latest.connectURL != cfg.connectURL {
+			return nil
+		}
+		params := map[string]interface{}{"api": latest.name, "ws_client": latest.name, "ws_message_type": websocketMessageTypeLabel(msgType), "ws_message_text": string(data), "ws_connect_url": latest.connectURL, "ws_description": latest.description}
+		if msgType == websocket.BinaryMessage {
+			params["ws_message_base64"] = base64.StdEncoding.EncodeToString(data)
+		}
+		if msgType == websocket.TextMessage {
+			var decoded interface{}
+			if json.Unmarshal(data, &decoded) == nil {
+				params["ws_message_json"] = decoded
+			}
+		}
+		result, err := runJavaScript(latest.scriptPath, "", params)
+		if err != nil {
+			log.Printf("ws_client %s script error: %v", latest.name, err)
+			continue
+		}
+		if result = strings.TrimSpace(result); result != "" {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(result)); err != nil {
+				return fmt.Errorf("send error: %w", err)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -11,12 +11,14 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,6 +26,9 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"github.com/dop251/goja/ast"
+	"github.com/dop251/goja/parser"
+	"github.com/dop251/goja/token"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/natefinch/lumberjack"
@@ -91,6 +96,7 @@ func (e *EndpointConfig) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		endpointConfigAlias
 		ParamCheckLower string `json:"paramcheck"`
+		Check           string `json:"check"`
 		OutCheckLower   string `json:"outcheck"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -101,6 +107,9 @@ func (e *EndpointConfig) UnmarshalJSON(data []byte) error {
 	if strings.TrimSpace(e.ParamCheck) == "" {
 		e.ParamCheck = raw.ParamCheckLower
 	}
+	if strings.TrimSpace(e.ParamCheck) == "" {
+		e.ParamCheck = raw.Check
+	}
 	if strings.TrimSpace(e.OutCheck) == "" {
 		e.OutCheck = raw.OutCheckLower
 	}
@@ -108,6 +117,43 @@ func (e *EndpointConfig) UnmarshalJSON(data []byte) error {
 }
 
 type APIConfig map[string]EndpointConfig
+
+const apiTypeInclude = "include"
+
+// APIConfigSnapshot is one immutable, fully validated generation of api.json.
+// Published snapshots are never mutated after publication.
+type APIConfigSnapshot struct {
+	RootPath   string
+	Config     APIConfig
+	Sources    map[string]string
+	FileStates map[string]APIFileState
+	Schedules  map[string]scheduleJobConfig
+	WSClients  map[string]wsClientConfig
+}
+
+type APIFileState struct {
+	Exists bool
+	Hash   [sha256.Size]byte
+}
+
+type apiConfigLoadResult struct {
+	Snapshot *APIConfigSnapshot
+	Hash     [sha256.Size]byte
+}
+
+const (
+	schemaSourceParamCheck   = "paramCheck"
+	schemaSourceOutCheck     = "outCheck"
+	schemaSourceScriptLegacy = "scriptLegacy"
+	schemaSourceUnknown      = "unknown"
+)
+
+type APISchema struct {
+	Input        map[string]interface{}
+	Output       map[string]interface{}
+	InputSource  string
+	OutputSource string
+}
 
 type NyanResponse struct {
 	Name    string             `json:"name"`
@@ -180,7 +226,8 @@ type serviceFilePaths struct {
 // api.jsonから取得する設定
 var (
 	apiConfigMu        sync.RWMutex
-	apiConfig          APIConfig
+	apiConfig          APIConfig // compatibility alias; always matches apiSnapshot.Config
+	apiSnapshot        *APIConfigSnapshot
 	backgroundRuntimes *backgroundRuntimeManager
 )
 
@@ -256,24 +303,16 @@ func main() {
 	log.Printf("Config version: %s", globalConfig.Version)
 
 	// API設定をロードし、background定義を公開前に全件検証する。
-	initialConfig, initialHash, err := readAPIConfigFile(paths.API.Path, apiBaseDir)
+	initialConfig, err := readAPIConfigGraph(paths.API.Path, apiBaseDir)
 	if err != nil {
 		log.Fatal("Error loading API configuration:", err)
 	}
-	initialSchedules, err := buildScheduleJobConfigs(initialConfig)
-	if err != nil {
-		log.Fatal("Error loading schedule configuration:", err)
-	}
-	initialWSClients, err := buildWSClientConfigs(initialConfig)
-	if err != nil {
-		log.Fatal("Error loading WebSocket client configuration:", err)
-	}
-	setAPIConfig(initialConfig)
+	publishAPISnapshot(initialConfig.Snapshot)
 	backgroundRuntimes = newBackgroundRuntimeManager()
-	backgroundRuntimes.reconcile(initialSchedules, initialWSClients)
+	backgroundRuntimes.reconcile(initialConfig.Snapshot.Schedules, initialConfig.Snapshot.WSClients)
 	if config.APIHotReload.Enabled {
 		log.Printf("API hot reload enabled: interval=%s", apiHotReloadInterval)
-		go watchAPIConfig(paths.API.Path, apiBaseDir, apiHotReloadInterval, initialHash)
+		go watchAPIConfigGraph(paths.API.Path, apiBaseDir, apiHotReloadInterval, initialConfig.Snapshot.FileStates)
 	} else {
 		log.Printf("API hot reload disabled")
 	}
@@ -288,6 +327,7 @@ func main() {
 	r.Static("/js", resolvePath(exeDir, "./html/js"))
 
 	r.GET("/nyan", handleNyan)
+	r.GET("/nyan/*apiName", handleNyanDetail)
 	r.POST("/nyan-rpc", handleJSONRPC)
 
 	r.Any("/", func(c *gin.Context) {
@@ -431,11 +471,11 @@ func loadConfig(filename string) (Config, error) {
 
 // apiの設定を読み込みます。
 func loadAPIConfig(filePath string, apiBaseDir string) error {
-	config, _, err := readAPIConfigFile(filePath, apiBaseDir)
+	loaded, err := readAPIConfigGraph(filePath, apiBaseDir)
 	if err != nil {
 		return err
 	}
-	setAPIConfig(config)
+	publishAPISnapshot(loaded.Snapshot)
 	return nil
 }
 
@@ -452,20 +492,28 @@ func adjustAPIConfigPaths(config APIConfig, apiBaseDir string) {
 
 // handleAPIRequestOrWebSocket はAPIリクエストまたはWebSocketリクエストを処理します。
 func handleAPIRequestOrWebSocket(c *gin.Context, apiName string) bool {
-	config, ok := currentAPIConfig()[apiName]
+	snapshot := currentAPISnapshot()
+	if snapshot == nil {
+		return false
+	}
+	config, ok := snapshot.Config[apiName]
 	if !ok || !isRequestAPI(config) {
 		return false
 	}
 	if websocket.IsWebSocketUpgrade(c.Request) {
 		handleWebSocket(c, apiName, config)
 	} else {
-		handleAPIRequest(c, config)
+		handleAPIRequestWithSnapshot(c, snapshot, config)
 	}
 	return true
 }
 
 // handleAPIRequest はAPIリクエストを処理します。
 func handleAPIRequest(c *gin.Context, config EndpointConfig) {
+	handleAPIRequestWithSnapshot(c, currentAPISnapshot(), config)
+}
+
+func handleAPIRequestWithSnapshot(c *gin.Context, snapshot *APIConfigSnapshot, config EndpointConfig) {
 	// HTTP/2サーバープッシュの処理は削除
 
 	// 実行ファイルのディレクトリを取得
@@ -492,7 +540,7 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 		htmlPath = resolvePath(exeDir, config.HTML)
 	}
 
-	if allowed, handled := runParamCheck(c, config, exeDir, htmlPath, allParams); handled {
+	if allowed, handled := runParamCheckWithSnapshot(c, snapshot, config, exeDir, htmlPath, allParams); handled {
 		return
 	} else if !allowed {
 		return
@@ -511,7 +559,7 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 			Headers:     map[string]string{},
 			Body:        htmlContent,
 		}
-		if handled := runOutCheck(c, config, exeDir, htmlPath, allParams, response); handled {
+		if handled := runOutCheckWithSnapshot(c, snapshot, config, exeDir, htmlPath, allParams, response); handled {
 			return
 		}
 		writeAPIResponse(c, response)
@@ -519,7 +567,7 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 	}
 
 	// JavaScriptを実行し、結果を取得
-	resultValue, err := runJavaScriptValue(scriptPath, htmlPath, allParams)
+	resultValue, err := runJavaScriptValueWithSnapshot(snapshot, scriptPath, htmlPath, allParams)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -531,7 +579,7 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 		return
 	}
 
-	if handled := runOutCheck(c, config, exeDir, htmlPath, allParams, response); handled {
+	if handled := runOutCheckWithSnapshot(c, snapshot, config, exeDir, htmlPath, allParams, response); handled {
 		return
 	}
 
@@ -542,7 +590,7 @@ func handleAPIRequest(c *gin.Context, config EndpointConfig) {
 
 	// push 設定がある場合、対象のWebSocket接続に対してプッシュ
 	// API リクエスト完了後の push 処理
-	performPush(config, allParams)
+	performPushWithSnapshot(snapshot, config, allParams)
 
 }
 
@@ -645,7 +693,11 @@ func sendHTMLErrorResponse(w http.ResponseWriter, errorMessage string) {
 
 // runJavaScript はJavaScriptを実行します。
 func runJavaScript(scriptPath string, htmlPath string, allParams map[string]interface{}) (string, error) {
-	value, err := runJavaScriptValue(scriptPath, htmlPath, allParams)
+	return runJavaScriptWithSnapshot(currentAPISnapshot(), scriptPath, htmlPath, allParams)
+}
+
+func runJavaScriptWithSnapshot(snapshot *APIConfigSnapshot, scriptPath string, htmlPath string, allParams map[string]interface{}) (string, error) {
+	value, err := runJavaScriptValueWithSnapshot(snapshot, scriptPath, htmlPath, allParams)
 	if err != nil {
 		return "", err
 	}
@@ -671,11 +723,18 @@ func resolveCurrentAPINameFromContext(c *gin.Context) string {
 
 // callNyanAPIFromVM は、JavaScript(VM) から api.json 定義の API を内部実行します。
 func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (interface{}, error) {
+	return callNyanAPIFromVMWithSnapshot(currentAPISnapshot(), apiName, allParams)
+}
+
+func callNyanAPIFromVMWithSnapshot(snapshot *APIConfigSnapshot, apiName string, allParams map[string]interface{}) (interface{}, error) {
 	if strings.TrimSpace(apiName) == "" {
 		return nil, fmt.Errorf("api name is required")
 	}
 
-	apiCfg, found := currentAPIConfig()[apiName]
+	if snapshot == nil {
+		return nil, fmt.Errorf("API configuration is not loaded")
+	}
+	apiCfg, found := snapshot.Config[apiName]
 	if !found {
 		return nil, fmt.Errorf("API config not found: %s", apiName)
 	}
@@ -695,7 +754,7 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (interf
 	}
 	params["api"] = apiName
 
-	resultValue, err := runJavaScriptValue(apiCfg.Script, apiCfg.HTML, params)
+	resultValue, err := runJavaScriptValueWithSnapshot(snapshot, apiCfg.Script, apiCfg.HTML, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run API %s: %w", apiName, err)
 	}
@@ -714,6 +773,10 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (interf
 }
 
 func runJavaScriptValue(scriptPath string, htmlPath string, allParams map[string]interface{}) (goja.Value, error) {
+	return runJavaScriptValueWithSnapshot(currentAPISnapshot(), scriptPath, htmlPath, allParams)
+}
+
+func runJavaScriptValueWithSnapshot(snapshot *APIConfigSnapshot, scriptPath string, htmlPath string, allParams map[string]interface{}) (goja.Value, error) {
 	// 実行ファイルのディレクトリを取得
 	exePath, err := os.Executable()
 	if err != nil {
@@ -725,7 +788,7 @@ func runJavaScriptValue(scriptPath string, htmlPath string, allParams map[string
 	scriptPath = resolvePath(exeDir, scriptPath)
 
 	// goja ランタイムのセットアップ（リクエストごとに新しいランタイムを作る）
-	runtime := setupGojaRuntime()
+	runtime := setupGojaRuntimeWithSnapshot(snapshot)
 
 	// ライブラリの JavaScript ファイルを読み込み
 	var jsLibCode string
@@ -813,6 +876,10 @@ func collectRequestParams(c *gin.Context, defaultAPI string) (map[string]interfa
 }
 
 func runParamCheck(c *gin.Context, config EndpointConfig, exeDir string, htmlPath string, allParams map[string]interface{}) (bool, bool) {
+	return runParamCheckWithSnapshot(c, currentAPISnapshot(), config, exeDir, htmlPath, allParams)
+}
+
+func runParamCheckWithSnapshot(c *gin.Context, snapshot *APIConfigSnapshot, config EndpointConfig, exeDir string, htmlPath string, allParams map[string]interface{}) (bool, bool) {
 	checkOnly := isCheckOnlyMode(allParams)
 	paramCheckPath := strings.TrimSpace(config.ParamCheck)
 	if paramCheckPath == "" {
@@ -830,7 +897,7 @@ func runParamCheck(c *gin.Context, config EndpointConfig, exeDir string, htmlPat
 	c.Writer.Header().Set("Cache-Control", "no-store")
 	c.Writer.Header().Set("Pragma", "no-cache")
 
-	resultValue, err := runJavaScriptValue(resolvePath(exeDir, paramCheckPath), htmlPath, allParams)
+	resultValue, err := runJavaScriptValueWithSnapshot(snapshot, resolvePath(exeDir, paramCheckPath), htmlPath, allParams)
 	if err != nil {
 		writeParamCheckResponse(c, newParamCheckError(http.StatusInternalServerError, err.Error()))
 		return false, true
@@ -859,6 +926,10 @@ func isCheckOnlyMode(allParams map[string]interface{}) bool {
 }
 
 func runOutCheck(c *gin.Context, config EndpointConfig, exeDir string, htmlPath string, allParams map[string]interface{}, response APIResponse) bool {
+	return runOutCheckWithSnapshot(c, currentAPISnapshot(), config, exeDir, htmlPath, allParams, response)
+}
+
+func runOutCheckWithSnapshot(c *gin.Context, snapshot *APIConfigSnapshot, config EndpointConfig, exeDir string, htmlPath string, allParams map[string]interface{}, response APIResponse) bool {
 	outCheckPath := strings.TrimSpace(config.OutCheck)
 	if outCheckPath == "" {
 		return false
@@ -879,7 +950,7 @@ func runOutCheck(c *gin.Context, config EndpointConfig, exeDir string, htmlPath 
 	checkParams["nyan_output_body"] = string(response.Body)
 	checkParams["nyan_output_body_base64"] = base64.StdEncoding.EncodeToString(response.Body)
 
-	resultValue, err := runJavaScriptValue(resolvePath(exeDir, outCheckPath), htmlPath, checkParams)
+	resultValue, err := runJavaScriptValueWithSnapshot(snapshot, resolvePath(exeDir, outCheckPath), htmlPath, checkParams)
 	if err != nil {
 		writeParamCheckResponse(c, newParamCheckError(http.StatusInternalServerError, err.Error()))
 		return true
@@ -1099,12 +1170,16 @@ func isRequestAPI(config EndpointConfig) bool {
 // dispatchDynamicEndpoint resolves the request against one immutable API snapshot.
 func dispatchDynamicEndpoint(c *gin.Context) bool {
 	requestPath := strings.TrimPrefix(c.Request.URL.Path, "/")
-	config := currentAPIConfig()
+	snapshot := currentAPISnapshot()
+	if snapshot == nil {
+		return false
+	}
+	config := snapshot.Config
 	if endpoint, ok := config[requestPath]; ok && isRequestAPI(endpoint) {
 		if websocket.IsWebSocketUpgrade(c.Request) {
 			handleWebSocket(c, requestPath, endpoint)
 		} else {
-			handleAPIRequest(c, endpoint)
+			handleAPIRequestWithSnapshot(c, snapshot, endpoint)
 		}
 		return true
 	}
@@ -1125,11 +1200,15 @@ func dispatchDynamicEndpoint(c *gin.Context) bool {
 	if endpointName == "" {
 		return false
 	}
-	servePublicEndpoint(c, endpointName, endpoint)
+	servePublicEndpointWithSnapshot(c, snapshot, endpointName, endpoint)
 	return true
 }
 
 func servePublicEndpoint(c *gin.Context, endpoint string, config EndpointConfig) {
+	servePublicEndpointWithSnapshot(c, currentAPISnapshot(), endpoint, config)
+}
+
+func servePublicEndpointWithSnapshot(c *gin.Context, snapshot *APIConfigSnapshot, endpoint string, config EndpointConfig) {
 	publicPath := strings.TrimSpace(config.Path)
 	if publicPath == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "public path is missing"})
@@ -1146,7 +1225,7 @@ func servePublicEndpoint(c *gin.Context, endpoint string, config EndpointConfig)
 	allParams["nyan_public_path"] = requestedPath
 	ginContext = c
 	defer func() { ginContext = nil }()
-	if allowed, handled := runParamCheck(c, config, filepath.Dir(publicPath), "", allParams); handled || !allowed {
+	if allowed, handled := runParamCheckWithSnapshot(c, snapshot, config, filepath.Dir(publicPath), "", allParams); handled || !allowed {
 		return
 	}
 	if requestedPath == "" || !filepath.IsLocal(requestedPath) {
@@ -1170,7 +1249,7 @@ func servePublicEndpoint(c *gin.Context, endpoint string, config EndpointConfig)
 			return
 		}
 		response := APIResponse{Status: http.StatusOK, ContentType: http.DetectContentType(content), Headers: map[string]string{}, Body: content}
-		if runOutCheck(c, config, filepath.Dir(publicPath), "", allParams, response) {
+		if runOutCheckWithSnapshot(c, snapshot, config, filepath.Dir(publicPath), "", allParams, response) {
 			return
 		}
 	}
@@ -1578,6 +1657,10 @@ func initLogger(logConfig LogConfig, baseDir string) {
 
 // setupGojaRuntime は goja のランタイムをセットアップします。
 func setupGojaRuntime() *goja.Runtime {
+	return setupGojaRuntimeWithSnapshot(currentAPISnapshot())
+}
+
+func setupGojaRuntimeWithSnapshot(snapshot *APIConfigSnapshot) *goja.Runtime {
 	vm := goja.New()
 
 	// getAPI 関数の登録
@@ -1720,7 +1803,7 @@ func setupGojaRuntime() *goja.Runtime {
 			panic(vm.ToValue("nyanCallMe: api is required"))
 		}
 
-		result, err := callNyanAPIFromVM(apiName, params)
+		result, err := callNyanAPIFromVMWithSnapshot(snapshot, apiName, params)
 		if err != nil {
 			panic(vm.ToValue(err.Error()))
 		}
@@ -1847,7 +1930,7 @@ func cp932ToUTF8(data []byte) (string, error) {
 func handleNyan(c *gin.Context) {
 	apis := make(map[string]ApiData)
 	for apiName, cfg := range currentAPIConfig() {
-		if strings.TrimSpace(cfg.Type) == apiTypeSchedule {
+		if !isRequestAPI(cfg) {
 			continue
 		}
 		apis[apiName] = ApiData{
@@ -1864,6 +1947,36 @@ func handleNyan(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// handleNyanDetail publishes documentation schemas for one normal API.
+func handleNyanDetail(c *gin.Context) {
+	apiName := strings.TrimPrefix(c.Param("apiName"), "/")
+	if apiName == "" {
+		handleNyan(c)
+		return
+	}
+	config, exists := currentAPIConfig()[apiName]
+	if !exists || !isRequestAPI(config) {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("API not found: %s", apiName)})
+		return
+	}
+	schema, err := resolveAPISchema(config)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to resolve API schemas: %s", apiName), "detail": err.Error()})
+		return
+	}
+	result := gin.H{
+		"api": apiName, "type": "api", "description": config.Description,
+		"inputSchema": schema.Input, "outputSchema": schema.Output,
+		"schemaSource": gin.H{"input": schema.InputSource, "output": schema.OutputSource},
+	}
+	if schema.InputSource == schemaSourceScriptLegacy {
+		if params, found, readErr := readStaticLegacyAcceptedParams(config.Script); readErr == nil && found {
+			result["nyanAcceptedParams"] = params
+		}
+	}
+	c.JSON(http.StatusOK, result)
 }
 
 func nyanGetFile(vm *goja.Runtime) func(call goja.FunctionCall) goja.Value {
@@ -1955,7 +2068,12 @@ func handleJSONRPC(c *gin.Context) {
 	}
 
 	// 3) api.json から、リクエストされたAPI設定を取得
-	config, exists := currentAPIConfig()[rpcReq.Method]
+	snapshot := currentAPISnapshot()
+	if snapshot == nil {
+		respondJSONRPCError(c, rpcReq.ID, -32603, "API configuration is not loaded", nil)
+		return
+	}
+	config, exists := snapshot.Config[rpcReq.Method]
 	if !exists {
 		respondJSONRPCError(c, rpcReq.ID, -32601, fmt.Sprintf("API not found: %s", rpcReq.Method), nil)
 		return
@@ -1993,21 +2111,21 @@ func handleJSONRPC(c *gin.Context) {
 		htmlPath = resolvePath(exeDir, config.HTML)
 	}
 
-	if allowed, handled := runParamCheck(c, config, exeDir, htmlPath, allParams); handled {
+	if allowed, handled := runParamCheckWithSnapshot(c, snapshot, config, exeDir, htmlPath, allParams); handled {
 		return
 	} else if !allowed {
 		return
 	}
 
 	// 7) メインのスクリプト実行（runJavaScript は既存関数）
-	resultStr, err := runJavaScript(scriptPath, htmlPath, allParams)
+	resultStr, err := runJavaScriptWithSnapshot(snapshot, scriptPath, htmlPath, allParams)
 	if err != nil {
 		respondJSONRPCError(c, rpcReq.ID, -32603, "Script execution error", err.Error())
 		return
 	}
 
 	// 8) Push 処理（必要な場合）
-	performPush(config, allParams)
+	performPushWithSnapshot(snapshot, config, allParams)
 
 	// 10) JSON-RPC 成功レスポンスを構築して返却
 	rpcResp := JSONRPCResponse{
@@ -2033,10 +2151,17 @@ func respondJSONRPCError(c *gin.Context, id interface{}, code int, message strin
 
 // performPush は指定された config に対して push 処理を行います。
 func performPush(config EndpointConfig, allParams map[string]interface{}) {
+	performPushWithSnapshot(currentAPISnapshot(), config, allParams)
+}
+
+func performPushWithSnapshot(snapshot *APIConfigSnapshot, config EndpointConfig, allParams map[string]interface{}) {
 	if config.Push == "" {
 		return
 	}
-	pushConfig, ok := currentAPIConfig()[config.Push]
+	if snapshot == nil {
+		return
+	}
+	pushConfig, ok := snapshot.Config[config.Push]
 	if !ok {
 		log.Printf("Push target %s not found in apiConfig", config.Push)
 		return
@@ -2058,7 +2183,7 @@ func performPush(config EndpointConfig, allParams map[string]interface{}) {
 		}
 		pushResult = string(content)
 	} else {
-		result, err := runJavaScript(scriptPath, htmlPath, allParams)
+		result, err := runJavaScriptWithSnapshot(snapshot, scriptPath, htmlPath, allParams)
 		if err != nil {
 			log.Printf("Failed to run push script: %v", err)
 			return
@@ -2077,6 +2202,259 @@ func performPush(config EndpointConfig, allParams map[string]interface{}) {
 			}
 		}
 	}
+}
+
+func parseStaticJavaScriptValue(filename, source string) (interface{}, error) {
+	program, err := parser.ParseFile(nil, filename, "("+source+");", 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse static JavaScript value: %w", err)
+	}
+	if len(program.Body) != 1 {
+		return nil, fmt.Errorf("parse static JavaScript value: expected one expression")
+	}
+	statement, ok := program.Body[0].(*ast.ExpressionStatement)
+	if !ok {
+		return nil, fmt.Errorf("parse static JavaScript value: expected an expression, got %T", program.Body[0])
+	}
+	return convertStaticJavaScriptValue(statement.Expression, "$")
+}
+
+func convertStaticJavaScriptValue(expression ast.Expression, path string) (interface{}, error) {
+	switch value := expression.(type) {
+	case *ast.ObjectLiteral:
+		result := make(map[string]interface{}, len(value.Value))
+		for _, rawProperty := range value.Value {
+			property, ok := rawProperty.(*ast.PropertyKeyed)
+			if !ok {
+				return nil, fmt.Errorf("static JavaScript value at %s: unsupported property %T", path, rawProperty)
+			}
+			if property.Computed || property.Kind != ast.PropertyKindValue {
+				return nil, fmt.Errorf("static JavaScript value at %s: dynamic properties are not supported", path)
+			}
+			keyLiteral, ok := property.Key.(*ast.StringLiteral)
+			if !ok {
+				return nil, fmt.Errorf("static JavaScript value at %s: property names must be strings", path)
+			}
+			key := keyLiteral.Value.String()
+			if _, exists := result[key]; exists {
+				return nil, fmt.Errorf("static JavaScript value at %s: duplicate property %q", path, key)
+			}
+			converted, err := convertStaticJavaScriptValue(property.Value, path+"."+key)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = converted
+		}
+		return result, nil
+	case *ast.ArrayLiteral:
+		result := make([]interface{}, len(value.Value))
+		for index, item := range value.Value {
+			if item == nil {
+				return nil, fmt.Errorf("static JavaScript value at %s[%d]: array holes are not supported", path, index)
+			}
+			converted, err := convertStaticJavaScriptValue(item, fmt.Sprintf("%s[%d]", path, index))
+			if err != nil {
+				return nil, err
+			}
+			result[index] = converted
+		}
+		return result, nil
+	case *ast.StringLiteral:
+		return value.Value.String(), nil
+	case *ast.NumberLiteral:
+		return staticJavaScriptNumber(value.Value, path)
+	case *ast.BooleanLiteral:
+		return value.Value, nil
+	case *ast.NullLiteral:
+		return nil, nil
+	case *ast.UnaryExpression:
+		if value.Postfix || (value.Operator != token.MINUS && value.Operator != token.PLUS) {
+			return nil, fmt.Errorf("static JavaScript value at %s: unary operator is not supported", path)
+		}
+		numberLiteral, ok := value.Operand.(*ast.NumberLiteral)
+		if !ok {
+			return nil, fmt.Errorf("static JavaScript value at %s: unary requires a numeric literal", path)
+		}
+		number, err := staticJavaScriptNumber(numberLiteral.Value, path)
+		if err != nil || value.Operator == token.PLUS {
+			return number, err
+		}
+		switch number := number.(type) {
+		case int64:
+			return -number, nil
+		case float64:
+			return -number, nil
+		}
+	}
+	return nil, fmt.Errorf("static JavaScript value at %s: expressions of type %T are not supported", path, expression)
+}
+
+func staticJavaScriptNumber(value interface{}, path string) (interface{}, error) {
+	switch number := value.(type) {
+	case int64:
+		return number, nil
+	case float64:
+		if math.IsInf(number, 0) || math.IsNaN(number) {
+			return nil, fmt.Errorf("static JavaScript value at %s: non-finite number", path)
+		}
+		return number, nil
+	default:
+		return nil, fmt.Errorf("static JavaScript value at %s: numeric value %T is not JSON-compatible", path, value)
+	}
+}
+
+func extractStaticJavaScriptConstant(filename string, source []byte, constantName string) (interface{}, bool, error) {
+	program, err := parser.ParseFile(nil, filename, source, 0)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse JavaScript file %s: %w", filename, err)
+	}
+	var initializer ast.Expression
+	for _, statement := range program.Body {
+		switch declaration := statement.(type) {
+		case *ast.LexicalDeclaration:
+			for _, binding := range declaration.List {
+				identifier, ok := binding.Target.(*ast.Identifier)
+				if !ok || identifier.Name.String() != constantName {
+					continue
+				}
+				if declaration.Token != token.CONST {
+					return nil, false, fmt.Errorf("JavaScript file %s: %s must be declared with const", filename, constantName)
+				}
+				if initializer != nil {
+					return nil, false, fmt.Errorf("JavaScript file %s: duplicate declaration of %s", filename, constantName)
+				}
+				if binding.Initializer == nil {
+					return nil, false, fmt.Errorf("JavaScript file %s: %s has no initializer", filename, constantName)
+				}
+				initializer = binding.Initializer
+			}
+		case *ast.VariableStatement:
+			for _, binding := range declaration.List {
+				if identifier, ok := binding.Target.(*ast.Identifier); ok && identifier.Name.String() == constantName {
+					return nil, false, fmt.Errorf("JavaScript file %s: %s must be declared with const", filename, constantName)
+				}
+			}
+		}
+	}
+	if initializer == nil {
+		return nil, false, nil
+	}
+	converted, err := convertStaticJavaScriptValue(initializer, constantName)
+	if err != nil {
+		return nil, false, fmt.Errorf("JavaScript file %s: %w", filename, err)
+	}
+	return converted, true, nil
+}
+
+func readStaticJavaScriptObjectConstant(filePath, constantName string) (map[string]interface{}, bool, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, false, err
+	}
+	value, found, err := extractStaticJavaScriptConstant(filePath, data, constantName)
+	if err != nil || !found {
+		return nil, found, err
+	}
+	object, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("JavaScript file %s: %s must be a static object literal", filePath, constantName)
+	}
+	return object, true, nil
+}
+
+func readOptionalStaticJavaScriptObjectConstant(filePath, constantName string) (map[string]interface{}, bool, error) {
+	if _, err := os.Stat(filePath); err != nil {
+		return nil, false, nil
+	}
+	return readStaticJavaScriptObjectConstant(filePath, constantName)
+}
+
+func readStaticLegacyAcceptedParams(filePath string) (map[string]interface{}, bool, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, false, err
+	}
+	value, found, err := extractStaticJavaScriptConstant(filePath, data, "nyanAcceptedParams")
+	if err != nil || !found {
+		return nil, found, err
+	}
+	params, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("nyanAcceptedParams must be a static object literal")
+	}
+	return params, true, nil
+}
+
+func resolveAPISchema(config EndpointConfig) (APISchema, error) {
+	resolved := APISchema{Input: map[string]interface{}{}, Output: map[string]interface{}{}, InputSource: schemaSourceUnknown, OutputSource: schemaSourceUnknown}
+	if config.ParamCheck != "" {
+		input, found, err := readOptionalStaticJavaScriptObjectConstant(config.ParamCheck, "nyanInputSchema")
+		if err != nil {
+			return APISchema{}, fmt.Errorf("input schema from paramCheck: %w", err)
+		}
+		if found {
+			resolved.Input, resolved.InputSource = input, schemaSourceParamCheck
+		}
+	}
+	if config.OutCheck != "" {
+		output, found, err := readOptionalStaticJavaScriptObjectConstant(config.OutCheck, "nyanOutputSchema")
+		if err != nil {
+			return APISchema{}, fmt.Errorf("output schema from outCheck: %w", err)
+		}
+		if found {
+			resolved.Output, resolved.OutputSource = output, schemaSourceOutCheck
+		}
+	}
+	if config.Script != "" && resolved.InputSource == schemaSourceUnknown {
+		params, found, err := readStaticLegacyAcceptedParams(config.Script)
+		if err == nil && found {
+			resolved.Input, resolved.InputSource = legacyInputSchema(params), schemaSourceScriptLegacy
+		}
+	}
+	return resolved, nil
+}
+
+func legacyInputSchema(params map[string]interface{}) map[string]interface{} {
+	properties := make(map[string]interface{}, len(params))
+	for name, value := range params {
+		properties[name] = legacyValueSchema(value)
+	}
+	return map[string]interface{}{"type": "object", "properties": properties, "additionalProperties": true}
+}
+
+func legacyValueSchema(value interface{}) map[string]interface{} {
+	schema := map[string]interface{}{}
+	switch value := value.(type) {
+	case string:
+		schema["type"] = "string"
+	case bool:
+		schema["type"] = "boolean"
+	case int64, int, int32:
+		schema["type"] = "integer"
+	case float64:
+		if math.Trunc(value) == value {
+			schema["type"] = "integer"
+		} else {
+			schema["type"] = "number"
+		}
+	case map[string]interface{}:
+		properties := map[string]interface{}{}
+		for name, item := range value {
+			properties[name] = legacyValueSchema(item)
+		}
+		schema["type"], schema["properties"], schema["additionalProperties"] = "object", properties, true
+	case []interface{}:
+		schema["type"] = "array"
+		if len(value) > 0 {
+			schema["items"] = legacyValueSchema(value[0])
+		} else {
+			schema["items"] = map[string]interface{}{}
+		}
+	default:
+		return schema
+	}
+	schema["examples"] = []interface{}{value}
+	return schema
 }
 
 const defaultAPIHotReloadCheckInterval = time.Second
@@ -2107,6 +2485,9 @@ func parseAPIHotReloadInterval(value string) (time.Duration, error) {
 }
 
 func decodeAPIConfig(data []byte, apiBaseDir string) (APIConfig, error) {
+	if err := validateNoDuplicateJSONKeys(data); err != nil {
+		return nil, fmt.Errorf("decode api JSON: %w", err)
+	}
 	var config APIConfig
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("decode api JSON: %w", err)
@@ -2118,14 +2499,21 @@ func decodeAPIConfig(data []byte, apiBaseDir string) (APIConfig, error) {
 	return config, nil
 }
 
+// readAPIConfigFile remains as the single-file compatibility entry point used
+// by existing callers and tests. Production loading uses readAPIConfigGraph.
 func readAPIConfigFile(path, apiBaseDir string) (APIConfig, [sha256.Size]byte, error) {
-	data, err := os.ReadFile(path)
+	loaded, err := readAPIConfigGraph(path, apiBaseDir)
 	if err != nil {
 		return nil, [sha256.Size]byte{}, fmt.Errorf("read api file: %w", err)
 	}
-	hash := sha256.Sum256(data)
-	config, err := decodeAPIConfig(data, apiBaseDir)
-	return config, hash, err
+	return loaded.Snapshot.Config, loaded.Hash, nil
+}
+
+func currentAPISnapshot() *APIConfigSnapshot {
+	apiConfigMu.RLock()
+	snapshot := apiSnapshot
+	apiConfigMu.RUnlock()
+	return snapshot
 }
 
 func currentAPIConfig() APIConfig {
@@ -2136,8 +2524,23 @@ func currentAPIConfig() APIConfig {
 }
 
 func setAPIConfig(config APIConfig) {
+	if config == nil {
+		publishAPISnapshot(nil)
+		return
+	}
+	schedules, _ := buildScheduleJobConfigs(config)
+	wsClients, _ := buildWSClientConfigs(config)
+	publishAPISnapshot(&APIConfigSnapshot{Config: config, Sources: map[string]string{}, FileStates: map[string]APIFileState{}, Schedules: schedules, WSClients: wsClients})
+}
+
+func publishAPISnapshot(snapshot *APIConfigSnapshot) {
 	apiConfigMu.Lock()
-	apiConfig = config
+	apiSnapshot = snapshot
+	if snapshot == nil {
+		apiConfig = nil
+	} else {
+		apiConfig = snapshot.Config
+	}
 	apiConfigMu.Unlock()
 }
 
@@ -2180,6 +2583,312 @@ func watchAPIConfig(path, apiBaseDir string, interval time.Duration, initialHash
 	for range ticker.C {
 		hash, reloaded, err := reloadAPIConfigIfChanged(path, apiBaseDir, lastHash)
 		lastHash = hash
+		if err != nil {
+			if err.Error() != lastError {
+				log.Printf("API hot reload failed: %v; current API configuration remains active", err)
+			}
+			lastError = err.Error()
+			continue
+		}
+		lastError = ""
+		if reloaded {
+			log.Printf("API hot reload succeeded: api_count=%d", len(currentAPIConfig()))
+		}
+	}
+}
+
+type apiIncludeDefinition struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+type apiGraphLoader struct {
+	definitions APIConfig
+	sources     map[string]string
+	states      map[string]APIFileState
+}
+
+func readAPIConfigGraph(rootPath, apiBaseDir string) (*apiConfigLoadResult, error) {
+	rootPath = resolvePathFromBase(apiBaseDir, rootPath)
+	rootPath, err := filepath.Abs(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	loader := &apiGraphLoader{definitions: APIConfig{}, sources: map[string]string{}, states: map[string]APIFileState{}}
+	result := &apiConfigLoadResult{Snapshot: &APIConfigSnapshot{RootPath: rootPath, Config: loader.definitions, Sources: loader.sources, FileStates: loader.states}}
+	rootData, rootIdentity, err := loader.readFile(rootPath)
+	if err != nil {
+		return result, err
+	}
+	result.Hash = sha256.Sum256(rootData)
+	if err := loader.loadFile(rootPath, rootIdentity, rootData, "", nil); err != nil {
+		return result, err
+	}
+	schedules, err := buildScheduleJobConfigs(loader.definitions)
+	if err != nil {
+		return result, err
+	}
+	wsClients, err := buildWSClientConfigs(loader.definitions)
+	if err != nil {
+		return result, err
+	}
+	if err := verifyAPIFileStates(loader.states); err != nil {
+		return result, err
+	}
+	snapshot := &APIConfigSnapshot{RootPath: rootPath, Config: loader.definitions, Sources: loader.sources, FileStates: loader.states, Schedules: schedules, WSClients: wsClients}
+	result.Snapshot = snapshot
+	return result, nil
+}
+
+func (loader *apiGraphLoader) readFile(path string) ([]byte, string, error) {
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return nil, "", err
+	}
+	identity := absPath
+	if canonical, canonicalErr := filepath.EvalSymlinks(absPath); canonicalErr == nil {
+		identity = canonical
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		loader.states[identity] = APIFileState{Exists: false}
+		return nil, identity, fmt.Errorf("read api file %s: %w", absPath, err)
+	}
+	loader.states[identity] = APIFileState{Exists: true, Hash: sha256.Sum256(data)}
+	return data, identity, nil
+}
+
+func (loader *apiGraphLoader) loadFile(path, identity string, data []byte, prefix string, stack []string) error {
+	for _, active := range stack {
+		if active == identity {
+			return fmt.Errorf("include cycle detected at %s", path)
+		}
+	}
+	if err := validateNoDuplicateJSONKeys(data); err != nil {
+		return fmt.Errorf("decode api JSON %s: %w", path, err)
+	}
+	var definitions map[string]json.RawMessage
+	if err := json.Unmarshal(data, &definitions); err != nil {
+		return fmt.Errorf("decode api JSON %s: %w", path, err)
+	}
+	if definitions == nil {
+		return fmt.Errorf("decode api JSON %s: top-level value must be an object", path)
+	}
+	names := make([]string, 0, len(definitions))
+	for name := range definitions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	mounts := map[string]struct{}{}
+	for _, name := range names {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(definitions[name], &object); err != nil || object == nil {
+			if err == nil {
+				err = fmt.Errorf("definition must be an object")
+			}
+			return fmt.Errorf("decode API definition %q in %s: %w", name, path, err)
+		}
+		var header struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(definitions[name], &header); err != nil {
+			return fmt.Errorf("decode API definition %q in %s: %w", name, path, err)
+		}
+		if strings.TrimSpace(header.Type) == apiTypeInclude {
+			if err := validateIncludeMountName(name); err != nil {
+				return err
+			}
+			mounts[name] = struct{}{}
+		}
+	}
+	for mount := range mounts {
+		for _, name := range names {
+			if name != mount && strings.HasPrefix(name, mount+"/") {
+				return fmt.Errorf("include mount %q conflicts with API name %q in %s", mount, name, path)
+			}
+		}
+	}
+	for _, name := range names {
+		raw := definitions[name]
+		var header struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(raw, &header)
+		if strings.TrimSpace(header.Type) == apiTypeInclude {
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &fields); err != nil {
+				return err
+			}
+			for field := range fields {
+				if field != "type" && field != "path" {
+					return fmt.Errorf("include %q: unsupported field %q; only type and path are allowed", name, field)
+				}
+			}
+			var include apiIncludeDefinition
+			if err := json.Unmarshal(raw, &include); err != nil {
+				return fmt.Errorf("include %q: %w", name, err)
+			}
+			if strings.TrimSpace(include.Path) == "" {
+				return fmt.Errorf("include %q: path is empty", name)
+			}
+			childPath := resolvePathFromBase(filepath.Dir(path), include.Path)
+			childData, childIdentity, err := loader.readFile(childPath)
+			if err != nil {
+				return fmt.Errorf("include %q in %s: %w", name, path, err)
+			}
+			if err := loader.loadFile(childPath, childIdentity, childData, joinAPIName(prefix, name), append(stack, identity)); err != nil {
+				return err
+			}
+			continue
+		}
+		var endpoint EndpointConfig
+		if err := json.Unmarshal(raw, &endpoint); err != nil {
+			return fmt.Errorf("decode API definition %q in %s: %w", name, path, err)
+		}
+		endpointConfig := APIConfig{name: endpoint}
+		adjustAPIConfigPaths(endpointConfig, filepath.Dir(path))
+		fullName := joinAPIName(prefix, name)
+		if _, exists := loader.definitions[fullName]; exists {
+			return fmt.Errorf("duplicate expanded API name %q", fullName)
+		}
+		loader.definitions[fullName] = endpointConfig[name]
+		loader.sources[fullName] = path
+	}
+	return nil
+}
+
+func validateIncludeMountName(name string) error {
+	if name == "" || name == "." || name == ".." || strings.TrimSpace(name) != name || strings.Contains(name, "/") {
+		return fmt.Errorf("invalid include mount name %q", name)
+	}
+	return nil
+}
+
+func joinAPIName(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "/" + name
+}
+
+func validateNoDuplicateJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := consumeJSONValue(decoder, "$", nil); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple top-level JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder, path string, first json.Token) error {
+	token := first
+	var err error
+	if token == nil {
+		token, err = decoder.Token()
+		if err != nil {
+			return err
+		}
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]struct{}{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("invalid object key at %s", path)
+			}
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate key %q at %s", key, path)
+			}
+			seen[key] = struct{}{}
+			if err := consumeJSONValue(decoder, path+"."+key, nil); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		index := 0
+		for decoder.More() {
+			if err := consumeJSONValue(decoder, fmt.Sprintf("%s[%d]", path, index), nil); err != nil {
+				return err
+			}
+			index++
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return nil
+	}
+}
+
+func observeAPIFileStates(states map[string]APIFileState) map[string]APIFileState {
+	observed := make(map[string]APIFileState, len(states))
+	for path := range states {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			observed[path] = APIFileState{Exists: false}
+		} else {
+			observed[path] = APIFileState{Exists: true, Hash: sha256.Sum256(data)}
+		}
+	}
+	return observed
+}
+
+func verifyAPIFileStates(expected map[string]APIFileState) error {
+	observed := observeAPIFileStates(expected)
+	if !reflect.DeepEqual(observed, expected) {
+		return fmt.Errorf("api files changed while configuration was being loaded")
+	}
+	return nil
+}
+
+func reloadAPIConfigGraphIfChanged(path, apiBaseDir string, watched map[string]APIFileState) (map[string]APIFileState, bool, error) {
+	observed := observeAPIFileStates(watched)
+	if reflect.DeepEqual(observed, watched) {
+		return watched, false, nil
+	}
+	loaded, err := readAPIConfigGraph(path, apiBaseDir)
+	if err != nil {
+		if loaded != nil && loaded.Snapshot != nil {
+			for filePath, state := range loaded.Snapshot.FileStates {
+				observed[filePath] = state
+			}
+		}
+		return observed, false, err
+	}
+	current := currentAPISnapshot()
+	if current != nil && reflect.DeepEqual(current.Config, loaded.Snapshot.Config) && reflect.DeepEqual(current.Sources, loaded.Snapshot.Sources) {
+		return loaded.Snapshot.FileStates, false, nil
+	}
+	publishAPISnapshot(loaded.Snapshot)
+	if backgroundRuntimes != nil {
+		backgroundRuntimes.reconcile(loaded.Snapshot.Schedules, loaded.Snapshot.WSClients)
+	}
+	return loaded.Snapshot.FileStates, true, nil
+}
+
+func watchAPIConfigGraph(path, apiBaseDir string, interval time.Duration, initialStates map[string]APIFileState) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	watched := initialStates
+	lastError := ""
+	for range ticker.C {
+		states, reloaded, err := reloadAPIConfigGraphIfChanged(path, apiBaseDir, watched)
+		watched = states
 		if err != nil {
 			if err.Error() != lastError {
 				log.Printf("API hot reload failed: %v; current API configuration remains active", err)

--- a/main_test.go
+++ b/main_test.go
@@ -396,8 +396,8 @@ func TestLoadAPIConfigResolvesEndpointPathsFromAPIFileDirectory(t *testing.T) {
 			"path": "./public"
 		}
 	}`)
-	apiConfig = nil
-	t.Cleanup(func() { apiConfig = nil })
+	setAPIConfig(nil)
+	t.Cleanup(func() { setAPIConfig(nil) })
 
 	if err := loadAPIConfig(apiPath, apiBaseDir); err != nil {
 		t.Fatalf("loadAPIConfig() error = %v", err)
@@ -942,6 +942,181 @@ func assertParamCheckResponse(t *testing.T, body []byte, success bool, status in
 	}
 	if response.Status != status {
 		t.Fatalf("status = %d, want %d; body=%q", response.Status, status, string(body))
+	}
+}
+
+func TestReadAPIConfigGraphExpandsNestedIncludesAndResolvesPaths(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "api.json")
+	child := filepath.Join(dir, "sub", "api.json")
+	grandchild := filepath.Join(dir, "sub", "admin", "api.json")
+	writeTestFile(t, root, `{"root":{"script":"./root.js"},"sub":{"type":"include","path":"./sub/api.json"}}`)
+	writeTestFile(t, child, `{"item":{"script":"./item.js","html":"./item.html"},"admin":{"type":"include","path":"./admin/api.json"}}`)
+	writeTestFile(t, grandchild, `{"user":{"script":"./user.js","paramCheck":"./check.js","outCheck":"./out.js"}}`)
+
+	loaded, err := readAPIConfigGraph(root, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := loaded.Snapshot.Config
+	if len(config) != 3 {
+		t.Fatalf("api count = %d, want 3: %#v", len(config), config)
+	}
+	if got := config["sub/item"].Script; got != filepath.Join(dir, "sub", "item.js") {
+		t.Fatalf("sub/item script = %q", got)
+	}
+	if got := config["sub/item"].HTML; got != filepath.Join(dir, "sub", "item.html") {
+		t.Fatalf("sub/item html = %q", got)
+	}
+	if got := config["sub/admin/user"].ParamCheck; got != filepath.Join(dir, "sub", "admin", "check.js") {
+		t.Fatalf("nested paramCheck = %q", got)
+	}
+	if _, exists := config["sub"]; exists {
+		t.Fatal("include definition was published as an API")
+	}
+	if len(loaded.Snapshot.FileStates) != 3 {
+		t.Fatalf("watched files = %d, want 3", len(loaded.Snapshot.FileStates))
+	}
+}
+
+func TestReadAPIConfigGraphRejectsInvalidIncludes(t *testing.T) {
+	t.Run("cycle", func(t *testing.T) {
+		dir := t.TempDir()
+		root := filepath.Join(dir, "api.json")
+		child := filepath.Join(dir, "child.json")
+		writeTestFile(t, root, `{"child":{"type":"include","path":"./child.json"}}`)
+		writeTestFile(t, child, `{"root":{"type":"include","path":"./api.json"}}`)
+		if _, err := readAPIConfigGraph(root, dir); err == nil || !strings.Contains(err.Error(), "cycle") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+	t.Run("duplicate key", func(t *testing.T) {
+		dir := t.TempDir()
+		root := filepath.Join(dir, "api.json")
+		writeTestFile(t, root, `{"x":{"script":"a"},"x":{"script":"b"}}`)
+		if _, err := readAPIConfigGraph(root, dir); err == nil || !strings.Contains(err.Error(), "duplicate key") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+	t.Run("mount conflict", func(t *testing.T) {
+		dir := t.TempDir()
+		root := filepath.Join(dir, "api.json")
+		writeTestFile(t, root, `{"sub":{"type":"include","path":"child.json"},"sub/existing":{"script":"x.js"}}`)
+		writeTestFile(t, filepath.Join(dir, "child.json"), `{}`)
+		if _, err := readAPIConfigGraph(root, dir); err == nil || !strings.Contains(err.Error(), "conflicts") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestReloadAPIConfigGraphTracksGrandchildAndRecoversMissingInclude(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "api.json")
+	child := filepath.Join(dir, "child.json")
+	grandchild := filepath.Join(dir, "grandchild.json")
+	writeTestFile(t, root, `{"sub":{"type":"include","path":"child.json"}}`)
+	writeTestFile(t, child, `{"nested":{"type":"include","path":"grandchild.json"}}`)
+	writeTestFile(t, grandchild, `{"one":{"script":"one.js"}}`)
+	loaded, err := readAPIConfigGraph(root, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := currentAPISnapshot()
+	publishAPISnapshot(loaded.Snapshot)
+	t.Cleanup(func() { publishAPISnapshot(old) })
+
+	writeTestFile(t, grandchild, `{"two":{"script":"two.js"}}`)
+	states, reloaded, err := reloadAPIConfigGraphIfChanged(root, dir, loaded.Snapshot.FileStates)
+	if err != nil || !reloaded {
+		t.Fatalf("reloaded=%v err=%v", reloaded, err)
+	}
+	if _, ok := currentAPIConfig()["sub/nested/two"]; !ok {
+		t.Fatal("grandchild change was not published")
+	}
+
+	writeTestFile(t, child, `{"missing":{"type":"include","path":"missing.json"}}`)
+	states, reloaded, err = reloadAPIConfigGraphIfChanged(root, dir, states)
+	if err == nil || reloaded {
+		t.Fatalf("reloaded=%v err=%v", reloaded, err)
+	}
+	missing := filepath.Join(dir, "missing.json")
+	if _, watched := states[missing]; !watched {
+		t.Fatalf("missing candidate is not watched: %#v", states)
+	}
+	writeTestFile(t, missing, `{"ready":{"script":"ready.js"}}`)
+	_, reloaded, err = reloadAPIConfigGraphIfChanged(root, dir, states)
+	if err != nil || !reloaded {
+		t.Fatalf("recovery reloaded=%v err=%v", reloaded, err)
+	}
+	if _, ok := currentAPIConfig()["sub/missing/ready"]; !ok {
+		t.Fatal("created include was not published")
+	}
+}
+
+func TestHandleNyanDetailPublishesStaticSchemas(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	paramCheck := filepath.Join(dir, "param.js")
+	outCheck := filepath.Join(dir, "out.js")
+	writeTestFile(t, paramCheck, `const nyanInputSchema = {type:"object",properties:{id:{type:"integer"}},required:["id"]};`)
+	writeTestFile(t, outCheck, `const nyanOutputSchema = {type:"object",properties:{status:{const:200}}};`)
+	old := currentAPISnapshot()
+	setAPIConfig(APIConfig{"sub/get": {ParamCheck: paramCheck, OutCheck: outCheck, Description: "nested"}, "assets": {Type: apiTypePublic}})
+	t.Cleanup(func() { publishAPISnapshot(old) })
+	router := gin.New()
+	router.GET("/nyan", handleNyan)
+	router.GET("/nyan/*apiName", handleNyanDetail)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/nyan/sub/get", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	sources := response["schemaSource"].(map[string]interface{})
+	if sources["input"] != schemaSourceParamCheck || sources["output"] != schemaSourceOutCheck {
+		t.Fatalf("sources=%#v", sources)
+	}
+
+	list := httptest.NewRecorder()
+	router.ServeHTTP(list, httptest.NewRequest(http.MethodGet, "/nyan/", nil))
+	if strings.Contains(list.Body.String(), "assets") {
+		t.Fatalf("public API leaked into list: %s", list.Body.String())
+	}
+}
+
+func TestNyanCallMeKeepsCapturedSnapshotGeneration(t *testing.T) {
+	dir := t.TempDir()
+	caller := filepath.Join(dir, "caller.js")
+	oldTarget := filepath.Join(dir, "old.js")
+	newTarget := filepath.Join(dir, "new.js")
+	writeTestFile(t, caller, `JSON.stringify(nyanCallMe({api:"sub/target"}));`)
+	writeTestFile(t, oldTarget, `({status:200,generation:"old"});`)
+	writeTestFile(t, newTarget, `({status:200,generation:"new"});`)
+	captured := &APIConfigSnapshot{Config: APIConfig{"sub/caller": {Script: caller}, "sub/target": {Script: oldTarget}}}
+	latest := &APIConfigSnapshot{Config: APIConfig{"sub/caller": {Script: caller}, "sub/target": {Script: newTarget}}}
+	old := currentAPISnapshot()
+	publishAPISnapshot(latest)
+	t.Cleanup(func() { publishAPISnapshot(old) })
+
+	result, err := runJavaScriptWithSnapshot(captured, caller, "", map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, `"generation":"old"`) {
+		t.Fatalf("result=%q, want captured generation", result)
+	}
+}
+
+func TestStaticSchemaParserRejectsDynamicValues(t *testing.T) {
+	if _, err := parseStaticJavaScriptValue("schema.js", `{type:createType()}`); err == nil {
+		t.Fatal("dynamic function call was accepted")
+	}
+	if _, err := parseStaticJavaScriptValue("schema.js", `{...common}`); err == nil {
+		t.Fatal("spread property was accepted")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 )
 
 func TestRegisterPublicEndpointServesFiles(t *testing.T) {
@@ -412,6 +417,289 @@ func TestLoadAPIConfigResolvesEndpointPathsFromAPIFileDirectory(t *testing.T) {
 	}
 	if apiConfig["public"].Path != filepath.Join(apiBaseDir, "public") {
 		t.Fatalf("Path = %q, want api-relative path", apiConfig["public"].Path)
+	}
+}
+
+func TestParseAPIHotReloadInterval(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", time.Second, false},
+		{"250ms", 250 * time.Millisecond, false},
+		{"1m", time.Minute, false},
+		{"later", 0, true},
+		{"0s", 0, true},
+		{"-1s", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := parseAPIHotReloadInterval(tt.value)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("parseAPIHotReloadInterval(%q) error = nil", tt.value)
+			}
+			continue
+		}
+		if err != nil || got != tt.want {
+			t.Fatalf("parseAPIHotReloadInterval(%q) = %s, %v; want %s", tt.value, got, err, tt.want)
+		}
+	}
+}
+
+func TestConfigAPIHotReloadDefaultsAndOverrides(t *testing.T) {
+	tests := []struct {
+		data string
+		want APIHotReloadConfig
+	}{
+		{`{}`, APIHotReloadConfig{Enabled: true, Interval: "1s"}},
+		{`{"APIHotReload":{"Enabled":false}}`, APIHotReloadConfig{Enabled: false, Interval: "1s"}},
+		{`{"APIHotReload":{"Enabled":true,"Interval":"2s"}}`, APIHotReloadConfig{Enabled: true, Interval: "2s"}},
+	}
+	for _, tt := range tests {
+		var got Config
+		applyConfigDefaults(&got)
+		if err := json.Unmarshal([]byte(tt.data), &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.APIHotReload != tt.want {
+			t.Fatalf("APIHotReload = %#v, want %#v", got.APIHotReload, tt.want)
+		}
+	}
+}
+
+func TestDecodeAPIConfigResolvesAllRelativePaths(t *testing.T) {
+	base := t.TempDir()
+	config, err := decodeAPIConfig([]byte(`{"x":{"script":"s.js","html":"h.html","path":"pub","paramCheck":"p.js","outCheck":"o.js"}}`), base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := config["x"]
+	for label, value := range map[string]string{"script": got.Script, "html": got.HTML, "path": got.Path, "paramCheck": got.ParamCheck, "outCheck": got.OutCheck} {
+		if !filepath.IsAbs(value) {
+			t.Fatalf("%s path is not absolute: %q", label, value)
+		}
+	}
+}
+
+func TestReloadAPIConfigKeepsLastGoodDefinition(t *testing.T) {
+	apiDir := t.TempDir()
+	apiPath := filepath.Join(apiDir, "api.json")
+	writeTestFile(t, apiPath, `{"old":{"description":"active"}}`)
+	initial, initialHash, err := readAPIConfigFile(apiPath, apiDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setAPIConfig(initial)
+	oldManager := backgroundRuntimes
+	backgroundRuntimes = nil
+	t.Cleanup(func() { setAPIConfig(nil); backgroundRuntimes = oldManager })
+
+	writeTestFile(t, apiPath, `{"new":{"description":"updated"}}`)
+	hash, reloaded, err := reloadAPIConfigIfChanged(apiPath, apiDir, initialHash)
+	if err != nil || !reloaded {
+		t.Fatalf("reload=%t err=%v", reloaded, err)
+	}
+	if _, ok := currentAPIConfig()["old"]; ok {
+		t.Fatal("old API remains")
+	}
+
+	writeTestFile(t, apiPath, `{"broken":`)
+	invalidHash, reloaded, err := reloadAPIConfigIfChanged(apiPath, apiDir, hash)
+	if err == nil || reloaded {
+		t.Fatalf("invalid reload=%t err=%v", reloaded, err)
+	}
+	if _, ok := currentAPIConfig()["new"]; !ok {
+		t.Fatal("last-known-good config was lost")
+	}
+	secondHash, reloaded, err := reloadAPIConfigIfChanged(apiPath, apiDir, invalidHash)
+	if err != nil || reloaded || secondHash != invalidHash {
+		t.Fatalf("unchanged invalid content reprocessed: reload=%t err=%v", reloaded, err)
+	}
+
+	writeTestFile(t, apiPath, `{"fixed":{"description":"ok"}}`)
+	_, reloaded, err = reloadAPIConfigIfChanged(apiPath, apiDir, invalidHash)
+	if err != nil || !reloaded {
+		t.Fatalf("fixed reload=%t err=%v", reloaded, err)
+	}
+}
+
+func TestReloadAPIConfigRejectsInvalidBackgroundCandidate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api.json")
+	writeTestFile(t, path, `{"current":{}}`)
+	initial, hash, err := readAPIConfigFile(path, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setAPIConfig(initial)
+	t.Cleanup(func() { setAPIConfig(nil) })
+	writeTestFile(t, path, `{"job":{"type":"schedule","trigger":{"type":"cron","value":"* * * * *"}}}`)
+	_, reloaded, err := reloadAPIConfigIfChanged(path, dir, hash)
+	if err == nil || reloaded {
+		t.Fatalf("reload=%t err=%v", reloaded, err)
+	}
+	if _, ok := currentAPIConfig()["current"]; !ok {
+		t.Fatal("current config changed")
+	}
+}
+
+func TestDynamicDispatcherReflectsAddDeleteAndSlashName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	script := filepath.Join(dir, "hot.js")
+	writeTestFile(t, script, `"hot";`)
+	setAPIConfig(APIConfig{"nested/hot": {Script: script}})
+	t.Cleanup(func() { setAPIConfig(nil) })
+	router := gin.New()
+	router.NoRoute(func(c *gin.Context) {
+		if !dispatchDynamicEndpoint(c) {
+			c.Status(http.StatusNotFound)
+		}
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/nested/hot", nil))
+	if rec.Code != http.StatusOK || rec.Body.String() != "hot" {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	setAPIConfig(APIConfig{})
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/nested/hot", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("deleted status=%d", rec.Code)
+	}
+}
+
+func TestDynamicDispatcherUsesLongestPublicPrefix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	shortDir, longDir := filepath.Join(dir, "short"), filepath.Join(dir, "long")
+	if err := os.MkdirAll(shortDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(longDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(longDir, "file.txt"), "long")
+	setAPIConfig(APIConfig{"assets": {Type: apiTypePublic, Path: shortDir}, "assets/deep": {Type: apiTypePublic, Path: longDir}})
+	t.Cleanup(func() { setAPIConfig(nil) })
+	router := gin.New()
+	router.NoRoute(func(c *gin.Context) {
+		if !dispatchDynamicEndpoint(c) {
+			c.Status(http.StatusNotFound)
+		}
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/deep/file.txt", nil))
+	if rec.Code != http.StatusOK || rec.Body.String() != "long" {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAPIConfigConcurrentReadAndReplace(t *testing.T) {
+	setAPIConfig(APIConfig{"api": {Description: "initial"}})
+	t.Cleanup(func() { setAPIConfig(nil) })
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_ = currentAPIConfig()["api"]
+			}
+		}()
+	}
+	for i := 0; i < 1000; i++ {
+		setAPIConfig(APIConfig{"api": {Description: fmt.Sprintf("updated-%d", i)}})
+	}
+	wg.Wait()
+}
+
+func TestBackgroundRuntimeManagerUpdatesAndStopsSchedule(t *testing.T) {
+	manager := newBackgroundRuntimeManager()
+	firstSchedule, _ := parseCronSchedule("0 0 1 1 *")
+	first := scheduleJobConfig{name: "job", scriptPath: "/tmp/job-v1.js", trigger: TriggerConfig{Type: "cron", Value: "0 0 1 1 *"}, schedule: firstSchedule}
+	manager.reconcile(map[string]scheduleJobConfig{"job": first}, nil)
+	manager.mu.Lock()
+	runtime := manager.schedules["job"]
+	manager.mu.Unlock()
+	secondSchedule, _ := parseCronSchedule("0 0 2 1 *")
+	second := scheduleJobConfig{name: "job", scriptPath: "/tmp/job-v2.js", trigger: TriggerConfig{Type: "cron", Value: "0 0 2 1 *"}, schedule: secondSchedule}
+	manager.reconcile(map[string]scheduleJobConfig{"job": second}, nil)
+	manager.mu.Lock()
+	updated := manager.schedules["job"]
+	manager.mu.Unlock()
+	if updated != runtime {
+		t.Fatal("schedule update created a second runtime")
+	}
+	if got, active := runtime.current(false); !active || got.scriptPath != second.scriptPath {
+		t.Fatalf("config=%#v active=%t", got, active)
+	}
+	manager.reconcile(nil, nil)
+	waitForRuntimeSignal(t, runtime.done, "schedule stop")
+}
+
+func TestBackgroundRuntimeManagerReconnectsOnlyForURLChange(t *testing.T) {
+	firstURL, firstConnected, firstDisconnected := newHotReloadWebSocketServer(t)
+	secondURL, secondConnected, secondDisconnected := newHotReloadWebSocketServer(t)
+	manager := newBackgroundRuntimeManager()
+	first := wsClientConfig{name: "client", scriptPath: "/tmp/v1.js", connectURL: firstURL}
+	manager.reconcile(nil, map[string]wsClientConfig{"client": first})
+	waitForRuntimeSignal(t, firstConnected, "first connect")
+	manager.mu.Lock()
+	runtime := manager.wsClients["client"]
+	manager.mu.Unlock()
+	soft := first
+	soft.scriptPath = "/tmp/v2.js"
+	soft.description = "updated"
+	manager.reconcile(nil, map[string]wsClientConfig{"client": soft})
+	select {
+	case <-firstDisconnected:
+		t.Fatal("soft update disconnected")
+	case <-time.After(100 * time.Millisecond):
+	}
+	changed := soft
+	changed.connectURL = secondURL
+	manager.reconcile(nil, map[string]wsClientConfig{"client": changed})
+	waitForRuntimeSignal(t, firstDisconnected, "old disconnect")
+	waitForRuntimeSignal(t, secondConnected, "second connect")
+	manager.reconcile(nil, nil)
+	waitForRuntimeSignal(t, secondDisconnected, "second disconnect")
+	waitForRuntimeSignal(t, runtime.done, "ws client stop")
+}
+
+func newHotReloadWebSocketServer(t *testing.T) (string, <-chan struct{}, <-chan struct{}) {
+	t.Helper()
+	connected, disconnected := make(chan struct{}, 1), make(chan struct{}, 1)
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("local listener unavailable: %v", err)
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		connected <- struct{}{}
+		defer func() { disconnected <- struct{}{}; _ = conn.Close() }()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+	return "ws" + server.URL[len("http"):], connected, disconnected
+}
+
+func waitForRuntimeSignal(t *testing.T, signal <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
 	}
 }
 


### PR DESCRIPTION
# v0.0.15

## 概要

NyanPUIの設定ファイル運用と`api.json`の管理を改善し、以下に対応しました。

- `api.json` / `config.json`の読み込みパス指定
- `api.json`のホットリロード
- `api.json`の多段include
- `/nyan/{API名}`からのAPI入出力スキーマ公開
- includeされたschedule／ws_clientを含むバックグラウンド処理の動的更新

API定義は検証済みの不変スナップショットとして公開し、設定変更中のリクエストや`nyanCallMe`が異なる世代の定義を混在して参照しないようにしています。

MCP機能の移植は今回のスコープに含めていません。

## 主な変更

### 設定ファイルパスの指定

`api.json`と`config.json`の読み込み元を次の優先順位で指定できるようにしました。

1. CLIオプション（`--api`, `--config`）
2. 環境変数（`NYAN_API_PATH`, `NYAN_CONFIG_PATH`）
3. 実行ファイルと同じディレクトリのデフォルトファイル

起動ログには、解決した絶対パスと指定元を出力します。

相対パスは次の基準で解決します。

- 各`api.json`の`script` / `html` / `path` / `paramCheck` / `outCheck`: その定義を書いた`api.json`のディレクトリ
- `config.json`の`certPath` / `keyPath` / `javascript_include` / `log.Filename`: `config.json`のディレクトリ
- CLIオプションと環境変数の相対パス: NyanPUIを起動したカレントディレクトリ

### api.jsonのホットリロード

ルートおよびincludeされたすべての`api.json`を定期監視し、変更時にルートから定義全体を再解析します。

`config.json`へ次の設定を追加しました。

```json
"APIHotReload": {
  "Enabled": true,
  "Interval": "1s"
}
```

設定を省略した場合も、既定で有効・1秒間隔となります。

- 正常な定義だけを不変スナップショットとして一括公開
- 不正なJSONや設定は採用せず、直前の正常な定義で稼働を継続
- 同じ状態・同じエラーのログ重複出力を抑制
- 通常API、HTML API、public、JSON-RPC、`nyanCallMe`、WebSocket、pushへ変更を反映
- scheduleとws_clientの追加・更新・削除を再起動なしで反映
- ws_clientは`connectURL`変更時だけ再接続し、script／descriptionだけの変更では接続を維持

### api.jsonの多段include

`type: "include"`によりAPI定義を複数ファイルへ分割できるようにしました。

```json
{
  "health": {
    "script": "./javascript/health.js"
  },
  "sub": {
    "type": "include",
    "path": "./sub/api.json"
  }
}
```

子ファイル内のAPIは`sub/getItem`のような完全名で公開され、さらにincludeをネストできます。

展開後の完全名は以下で共通して使用されます。

- HTTP / WebSocket
- JSON-RPC
- `nyanCallMe`
- push
- public
- schedule
- ws_client

以下の不正状態は読み込みエラーとして検出します。

- includeの循環参照
- 重複JSONキー
- 展開後のAPI名重複
- マウント名と既存API名の衝突
- 空文字、`.`、`..`、前後の空白、`/`を含む不正なマウント名
- 存在しないinclude先
- `type`と`path`以外を持つinclude定義

include先が存在しない候補も監視対象に含めるため、ファイルの作成・修正だけで自動復旧できます。

### API入出力スキーマの公開

`paramCheck`のトップレベルに`nyanInputSchema`、`outCheck`に`nyanOutputSchema`を定義できるようにしました。

```javascript
const nyanInputSchema = {
  type: "object",
  properties: {
    id: {type: "integer"}
  },
  required: ["id"]
};
```

```javascript
const nyanOutputSchema = {
  type: "object",
  properties: {
    status: {const: 200},
    body: {type: "object"}
  },
  required: ["status", "body"]
};
```

`GET /nyan/{API名}`のレスポンスへ以下を追加します。

- `inputSchema`
- `outputSchema`
- `schemaSource`

入力スキーマの優先順位:

1. `paramCheck`の`nyanInputSchema`
2. 本体scriptの旧形式`nyanAcceptedParams`
3. `unknown`（空スキーマ）

出力スキーマの優先順位:

1. `outCheck`の`nyanOutputSchema`
2. `unknown`（空スキーマ）

旧形式の`nyanAcceptedParams`は後方互換性のため継続して読み取ります。legacy入力を使用した場合は、`nyanAcceptedParams`と推測した`inputSchema`の両方を返します。`nyanOutputColumns`はAPI詳細に出力しません。

スキーマはJavaScriptを実行せず、ASTから静的に読み取ります。オブジェクト、配列、文字列、数値、真偽値、`null`に対応し、関数呼び出し、spread、識別子参照などの動的な定義はスキーマ解決エラーになります。

スキーマファイルはAPI詳細リクエストごとに読み直すため、スキーマだけを変更した場合はNyanPUIの再起動や`api.json`の更新は不要です。

### スキーマと実行時処理の分離

公開したJSON Schemaによるリクエスト・レスポンスの自動検証は行いません。

- 実際の検証は従来どおり`paramCheck` / `outCheck`が担当
- 公開スキーマから実際のレスポンス値を生成・補完しない
- API本体のレスポンス形式は従来仕様を維持

### `/nyan`エンドポイント

- `/nyan`と`/nyan/`の両方で一覧を返す
- 一覧を通常APIだけに限定
- public、schedule、ws_clientを一覧・詳細から除外
- `/nyan/sub/admin/getItem`のような多段API名に対応
- 存在しないAPIまたは通常API以外の詳細は404を返す

### CI・依存関係

- `actions/setup-go`をv6へ更新
- GitHub ActionsのGoバージョンを`go.mod`から取得
- 実際に直接利用しているGoモジュールをdirect dependencyとして整理

## 互換性に関する注意

- 設定ファイルパスを指定しない場合は、従来どおり実行ファイルと同じディレクトリのファイルを使用します。
- `APIHotReload`を省略した場合は、ホットリロードが有効・1秒間隔になります。
- `paramCheck` / `paramcheck` / `check`の別名を利用できます。
- `outCheck` / `outcheck`の別名を利用できます。
- includeされていない既存API名に`/`を含める書き方は引き続き利用できます。
- `/nyan`の一覧は通常APIだけになり、publicとws_clientは表示されなくなります。
- 公開スキーマは実行時バリデーションには使用されません。
- MCP機能は今回の対象外です。

## 自動テスト

以下を実行し、すべて成功しています。

```bash
go test -count=1 .
go test -race -count=1 .
go vet .
go build .
git diff --check
```

主に以下をテストしています。

- CLI／環境変数／デフォルトによる設定ファイルパス解決
- API定義内およびconfig内の相対パス解決
- public、paramCheck、outCheckの既存動作
- ホットリロードの成功・失敗と最終正常設定の維持
- scheduleとws_clientの追加・更新・停止
- API設定の並行参照
- 多段includeと定義元ファイル基準のパス解決
- 循環参照、重複JSONキー、名前空間衝突、不正include定義
- 子・孫includeの変更検知と、存在しないinclude先からの復旧
- 明示入力・出力スキーマの静的抽出
- 動的なスキーマ定義の拒否
- `/nyan/{API名}`からのスキーマ公開
- `nyanCallMe`が呼び出し元と同じスナップショット世代を使用すること

## 手動動作確認

専用の一時環境と別ポートを使用し、以下を確認しました。

- ルート、子include、孫includeのHTTP実行
- `/nyan`と`/nyan/`の一覧取得
- `/nyan/sub/getItem`と`/nyan/sub/admin/status`の詳細取得
- includeされたpublicファイルの配信
- JSON-RPCからの完全API名による呼び出し
- `nyanCallMe`からの完全API名による内部呼び出し
- 子`api.json`および孫`api.json`単独変更のホットリロード
- スキーマファイル単独変更の即時反映
- 不正JSON中も直前の正常設定でAPIが継続すること
- 同一エラーのログが重複出力されないこと
- JSON修正後にホットリロードが自動復旧すること
